### PR TITLE
fix: valid conditional exports map (fixes #59, ERR_INVALID_PACKAGE_TARGET)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   "version": "0.0.27",
   "type": "module",
   "main": "dist/TimeWidget.min.js",
-  "exports": "dist/TimeWidget.min.js",
+  "exports": {
+    "import": "./dist/TimeWidget.esm.js",
+    "default": "./dist/TimeWidget.min.js"
+  },
   "module": "dist/TimeWidget.esm.js",
   "browser": "dist/TimeWidget.min.js",
   "unpkg": "dist/TimeWidget.min.js",


### PR DESCRIPTION
## What

Fixes the invalid `exports` field reported in #59.

`package.json` declared `"exports": "dist/TimeWidget.min.js"` — a target without a leading `./`, which the [Node.js package entry-points spec](https://nodejs.org/api/packages.html#exports) forbids. Node's strict ESM resolver rejects it with `ERR_INVALID_PACKAGE_TARGET`, so `time-widget` cannot be imported from Observable Framework, Vite, or other spec-compliant ESM bundlers.

## Change

```diff
-  "exports": "dist/TimeWidget.min.js",
+  "exports": {
+    "import": "./dist/TimeWidget.esm.js",
+    "default": "./dist/TimeWidget.min.js"
+  },
```

This also routes ESM consumers to the ESM build (`dist/TimeWidget.esm.js`) instead of the minified UMD bundle, while non-ESM consumers still get `dist/TimeWidget.min.js` via `default`.

## Verification

With this change, `time-widget` resolves, loads, and renders correctly in Observable Framework 1.13.4 (confirmed in a running app with brushing + reference curves). No source or build changes — only package metadata.

Closes #59