### PR TITLE
feat: programmatic axis zoom via ts.setDomains({x,y}) + ts.fullExtent

### DIFF
--- a/example/ResizeDomain.html
+++ b/example/ResizeDomain.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+
+<body>
+<!-- target for the main Widget -->
+<h1>Stock Prices</h1>
+<div id="target"></div>
+<label for="domainX">Domain X</label>
+<input type="range" min="0" max="100" value="0" id="domainX">
+<label for="domainY">Domain Y</label><input type="range" min="0" max="100" value="0" id="domainY">
+
+<!-- Load the libraries -->
+<script src="https://d3js.org/d3.v7.js"></script>
+<script src="../dist/TimeWidget.js"></script>
+
+<script>
+    let data = [
+        {Date: new Date("01/01/2023"), Open: 250, id: "Apple", group: "Technology"},
+        {Date: new Date("01/02/2023"), Open: 240, id: "Apple", group: "Technology"},
+        {Date: new Date("01/03/2023"), Open: 260, id: "Apple", group: "Technology"},
+        {Date: new Date("01/04/2023"), Open: 250, id: "Apple", group: "Technology"},
+        {Date: new Date("01/05/2023"), Open: 220, id: "Apple", group: "Technology"},
+        {Date: new Date("01/06/2023"), Open: 260, id: "Apple", group: "Technology"},
+    ];
+
+    let ts = TimeWidget(
+        data,
+        {
+            x: "Date", // Attribute to show in the X axis (Note that it also supports functions)
+            y: "Open", // Attribute to show in the Y axis (Note that it also supports functions)
+            id: "stock", // Attribute to group the input data (Note that it also supports functions)
+        }
+    );
+
+    ts.addEventListener("input", () => {
+        console.log("Selected", ts.value);
+    });
+
+    document.getElementById("target").appendChild(ts);
+    domainx = document.getElementById("domainX");
+    console.log(ts.ts.getExtent());
+    domainx.min = ts.ts.getExtent().x[0].getTime();
+    domainx.max = ts.ts.getExtent().x[1].getTime();
+    domainx.value = domainx.max;
+
+    domainx.addEventListener("input", () => {
+        ts.ts.setDomains({x: [+domainx.min, +domainx.value]});
+    });
+
+    domainy = document.getElementById("domainY");
+    domainy.min = ts.ts.getExtent().y[0];
+    domainy.max = ts.ts.getExtent().y[1];
+    domainy.value = domainy.max;
+
+    domainy.addEventListener("input", () => {
+        ts.ts.setDomains({y: [+domainy.min, +domainy.value]});
+    });
+
+</script>
+</body>
+</html>

--- a/src/TimeWidget.js
+++ b/src/TimeWidget.js
@@ -1,7 +1,7 @@
 ﻿import * as d3 from "d3";
 import {add, intervalToDuration, sub} from "date-fns";
 
-import {log, logPerformance} from "./utils.js";
+import {log, logPerformance, normalizeDomain} from "./utils.js";
 
 import TimelineDetails from "./TimelineDetails.js";
 import TimeLineOverview from "./TimeLineOverview";
@@ -415,8 +415,8 @@ function TimeWidget(
   }
 
   function initDomains({ xDataType, fData }) {
-    if (!xDomain) {
-      xDomain = fixAxis && _this ? _this.extent.x : d3.extent(fData, x); // Keep same axes as in the first rendering
+    if (!ts.xDomain) {
+      ts.xDomain = fixAxis && _this ? _this.extent.x : d3.extent(fData, x); // Keep same axes as in the first rendering
     }
 
     overviewX = xScale ? xScale.copy() : undefined;
@@ -425,7 +425,7 @@ function TimeWidget(
       // X is Date
       hasScaleTime = true;
       if (!overviewX) overviewX = d3.scaleTime();
-      overviewX.domain(xDomain);
+      overviewX.domain(ts.xDomain);
       if (!fmtX) {
         // It is a function of type d3.timeFormat. I don't like the way to check that it is a function of that type, but I don't know a better one.
         fmtX = d3.timeFormat("%Y-%m-%d");
@@ -441,7 +441,7 @@ function TimeWidget(
       // if (xDataType === "number") {
       // X is number
       if (!overviewX) overviewX = d3.scaleLinear();
-      overviewX.domain(xDomain);
+      overviewX.domain(ts.xDomain);
       if (!fmtX) {
         fmtX = d3.format(".1f");
       }
@@ -461,6 +461,11 @@ function TimeWidget(
       .range([height - ts.margin.top - ts.margin.bottom, 0])
       .nice()
       .clamp(true);
+
+    // Full data extent captured once, before any zoom narrows the domains.
+    if (!ts.fullExtent) {
+      ts.fullExtent = { x: d3.extent(fData, x), y: d3.extent(fData, y) };
+    }
   }
 
   function init() {
@@ -1472,6 +1477,13 @@ function TimeWidget(
         init();
         brushes.addFilters(status, true);
     };
+
+  ts.setDomains = ({ x, y } = {}) => {
+    if (x) ts.xDomain = normalizeDomain(x);
+    if (y) ts.yDomain = normalizeDomain(y);
+    ts.update();
+    return ts;
+  };
 
   // Remove possible previous event listener
   //target.removeEventListener("TimeWidget", onTimeWidgetEvent);

--- a/src/TimeWidget.js
+++ b/src/TimeWidget.js
@@ -460,11 +460,6 @@ function TimeWidget(
     overviewY
       .range([height - ts.margin.top - ts.margin.bottom, 0])
       .nice()
-
-    // Full data extent captured once, before any zoom narrows the domains.
-    if (!ts.fullExtent) {
-      ts.fullExtent = { x: d3.extent(fData, x), y: d3.extent(fData, y) };
-    }
   }
 
   function init() {
@@ -1419,6 +1414,14 @@ function TimeWidget(
     );
 
       let xDataType = typeof x(fData[0]);
+
+      // Full data extent captured once, before any zoom narrows the domains.
+      if (!ts.fullExtent) {
+          ts.fullExtent = {x: d3.extent(fData, x), y: d3.extent(fData, y)};
+      }
+
+      xDomain = normalizeDomain(xDomain, ts.extent);
+      yDomain = normalizeDomain(yDomain, ts.extent);
 
       initDomains({xDataType, fData});
 

--- a/src/TimeWidget.js
+++ b/src/TimeWidget.js
@@ -460,7 +460,6 @@ function TimeWidget(
     overviewY
       .range([height - ts.margin.top - ts.margin.bottom, 0])
       .nice()
-      .clamp(true);
 
     // Full data extent captured once, before any zoom narrows the domains.
     if (!ts.fullExtent) {
@@ -481,8 +480,8 @@ function TimeWidget(
     timelineOverview = TimeLineOverview({
       ts,
       element: divRender.node(),
-      width: width,
-      height: height,
+        width: width - margin.left - margin.right,
+        height: height - margin.top - margin.bottom,
       x,
       y,
       groupAttr: color,
@@ -673,8 +672,6 @@ function TimeWidget(
       data: groupedData,
       tooltipTarget: divRender.node(),
       contextMenuTarget: divRender.node(),
-      width,
-      height,
       xPartitions,
       yPartitions,
       x,
@@ -1457,8 +1454,7 @@ function TimeWidget(
     overviewY = d3
       .scaleLinear()
       .range([height - ts.margin.top - ts.margin.bottom, 0])
-      .nice()
-      .clamp(true);
+        .nice();
     init();
   }
 
@@ -1479,11 +1475,15 @@ function TimeWidget(
     };
 
   ts.setDomains = ({ x, y } = {}) => {
-      if (x) ts.xDomain = normalizeDomain(x, ts.fullExtent);
-      if (y) ts.yDomain = normalizeDomain(y, ts.fullExtent);
+      if (x) ts.xDomain = normalizeDomain(x, ts.fullExtent) || ts.xDomain;
+      if (y) ts.yDomain = normalizeDomain(y, ts.fullExtent) || ts.yDomain;
     ts.update();
     return ts;
   };
+
+    ts.getExtent = () => {
+        return ts.fullExtent;
+    };
 
   // Remove possible previous event listener
   //target.removeEventListener("TimeWidget", onTimeWidgetEvent);

--- a/src/TimeWidget.js
+++ b/src/TimeWidget.js
@@ -1479,8 +1479,8 @@ function TimeWidget(
     };
 
   ts.setDomains = ({ x, y } = {}) => {
-    if (x) ts.xDomain = normalizeDomain(x);
-    if (y) ts.yDomain = normalizeDomain(y);
+      if (x) ts.xDomain = normalizeDomain(x, ts.fullExtent);
+      if (y) ts.yDomain = normalizeDomain(y, ts.fullExtent);
     ts.update();
     return ts;
   };

--- a/src/TimeWidget.js
+++ b/src/TimeWidget.js
@@ -1424,10 +1424,11 @@ function TimeWidget(
 
     let xDataType = typeof x(fData[0]);
 
-    // Full data extent captured once, before any zoom narrows the domains.
-    if (!ts.fullExtent) {
-      ts.fullExtent = { x: d3.extent(fData, x), y: d3.extent(fData, y) };
-    }
+    // Full data extent, recomputed for each new dataset. Zooming goes through
+    // ts.update(), never through here, so this is not narrowed by a zoom — but
+    // it must follow the data: domains are clamped to fullExtent, so a stale
+    // one would make records outside the first dataset's range unreachable.
+    ts.fullExtent = { x: d3.extent(fData, x), y: d3.extent(fData, y) };
 
     // The xDomain/yDomain constructor options were copied onto ts.* at creation
     // time, before any data (and so before fullExtent) existed. Validate them

--- a/src/utils.js
+++ b/src/utils.js
@@ -97,5 +97,7 @@ export function normalizeDomain(domain, extent, {eps = 1e-6} = {}) {
         } else {
             return [lo, hi];
         }
+    } else {
+        console.warn("Unsupported domain type");
     }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -81,9 +81,9 @@ export function normalizeDomain(domain, extent, {eps = 1e-6} = {}) {
     if (Number.isNaN(lo) || Number.isNaN(hi)) return domain;
     if (lo > hi) [lo, hi] = [hi, lo];
     if (lo === hi) hi = lo + eps;
-    if (lo < extent[0]) lo = extent[0];
-    if (hi < extent[0]) hi = extent[0] + eps;
-    if (hi > extent[1]) hi = extent[1];
-    if (lo > extent[1]) lo = extent[1] - eps;
+    if (lo <= extent[0]) lo = extent[0];
+    if (hi <= extent[0]) hi = extent[0] + eps;
+    if (hi >= extent[1]) hi = extent[1];
+    if (lo >= extent[1]) lo = extent[1] - eps;
     return [lo, hi];
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,12 +74,16 @@ export const BrushAggregation = Object.freeze({
 // Normalize a numeric [lo, hi] domain: order endpoints, widen a zero-width
 // interval by eps. Non-numeric domains (e.g. Dates) and malformed input pass
 // through unchanged so the scaleTime path is never broken.
-export function normalizeDomain(domain, { eps = 1e-6 } = {}) {
-  if (!Array.isArray(domain) || domain.length !== 2) return domain;
-  let [lo, hi] = domain;
-  if (typeof lo !== "number" || typeof hi !== "number") return domain;
-  if (Number.isNaN(lo) || Number.isNaN(hi)) return domain;
-  if (lo > hi) [lo, hi] = [hi, lo];
-  if (lo === hi) hi = lo + eps;
-  return [lo, hi];
+export function normalizeDomain(domain, extent, {eps = 1e-6} = {}) {
+    if (!Array.isArray(domain) || domain.length !== 2) return domain;
+    let [lo, hi] = domain;
+    if (typeof lo !== "number" || typeof hi !== "number") return domain;
+    if (Number.isNaN(lo) || Number.isNaN(hi)) return domain;
+    if (lo > hi) [lo, hi] = [hi, lo];
+    if (lo === hi) hi = lo + eps;
+    if (lo < extent[0]) lo = extent[0];
+    if (hi < extent[0]) hi = extent[0] + eps;
+    if (hi > extent[1]) hi = extent[1];
+    if (lo > extent[1]) lo = extent[1] - eps;
+    return [lo, hi];
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,3 +70,16 @@ export const BrushAggregation = Object.freeze({
   And: "and",
     Or: "or",
 });
+
+// Normalize a numeric [lo, hi] domain: order endpoints, widen a zero-width
+// interval by eps. Non-numeric domains (e.g. Dates) and malformed input pass
+// through unchanged so the scaleTime path is never broken.
+export function normalizeDomain(domain, { eps = 1e-6 } = {}) {
+  if (!Array.isArray(domain) || domain.length !== 2) return domain;
+  let [lo, hi] = domain;
+  if (typeof lo !== "number" || typeof hi !== "number") return domain;
+  if (Number.isNaN(lo) || Number.isNaN(hi)) return domain;
+  if (lo > hi) [lo, hi] = [hi, lo];
+  if (lo === hi) hi = lo + eps;
+  return [lo, hi];
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,15 +75,27 @@ export const BrushAggregation = Object.freeze({
 // interval by eps. Non-numeric domains (e.g. Dates) and malformed input pass
 // through unchanged so the scaleTime path is never broken.
 export function normalizeDomain(domain, extent, {eps = 1e-6} = {}) {
-    if (!Array.isArray(domain) || domain.length !== 2) return domain;
+    if (!Array.isArray(domain) || domain.length !== 2) return null;
     let [lo, hi] = domain;
-    if (typeof lo !== "number" || typeof hi !== "number") return domain;
-    if (Number.isNaN(lo) || Number.isNaN(hi)) return domain;
     if (lo > hi) [lo, hi] = [hi, lo];
-    if (lo === hi) hi = lo + eps;
-    if (lo <= extent[0]) lo = extent[0];
-    if (hi <= extent[0]) hi = extent[0] + eps;
-    if (hi >= extent[1]) hi = extent[1];
-    if (lo >= extent[1]) lo = extent[1] - eps;
-    return [lo, hi];
+    let isDate = false;
+    if (lo instanceof Date && hi instanceof Date) {
+        lo = lo.getTime();
+        hi = hi.getTime();
+        isDate = true;
+    }
+
+    if (typeof lo === "number" && typeof hi === "number") {
+        if (Number.isNaN(lo) || Number.isNaN(hi)) return null;
+        if (lo === hi) hi = lo + eps;
+        if (lo <= extent[0]) lo = extent[0];
+        if (hi <= extent[0]) hi = extent[0] + eps;
+        if (hi >= extent[1]) hi = extent[1];
+        if (lo >= extent[1]) lo = extent[1] - eps;
+        if (isDate) {
+            return [new Date(lo), new Date(hi)];
+        } else {
+            return [lo, hi];
+        }
+    }
 }

--- a/tests/domain.test.js
+++ b/tests/domain.test.js
@@ -1,17 +1,29 @@
-import { normalizeDomain } from "../src/utils.js";
+import {normalizeDomain} from "../src/utils.js";
 
 test("passes through an already-valid numeric domain", () => {
-  expect(normalizeDomain([10, 40])).toEqual([10, 40]);
+  expect(normalizeDomain([10, 40], [0, 50])).toEqual([10, 40]);
 });
 
 test("swaps reversed endpoints", () => {
-  expect(normalizeDomain([40, 10])).toEqual([10, 40]);
+  expect(normalizeDomain([40, 10], [0, 50])).toEqual([10, 40]);
 });
 
-test("widens equal endpoints by eps", () => {
-  const [lo, hi] = normalizeDomain([20, 20], { eps: 1e-6 });
+test("Values outside the extend", () => {
+  let eps = 1e-6;
+  expect(normalizeDomain([10, 40], [20, 30],)).toEqual([20, 30]);
+  let [lo, hi] = normalizeDomain([40, 50], [20, 30], {eps: eps});
+  expect(hi).toBe(30);
+  expect(lo).toBeCloseTo(30 - eps, 9);
+  [lo, hi] = normalizeDomain([10, 20], [20, 30], {eps: eps});
+  expect(hi).toBeCloseTo(20 + eps, 9);
   expect(lo).toBe(20);
-  expect(hi).toBeCloseTo(20 + 1e-6, 9);
+
+});
+test("widens equal endpoints by eps", () => {
+  let eps = 1e-6;
+  const [lo, hi] = normalizeDomain([20, 20], [0, 50], {eps: eps});
+  expect(lo).toBe(20);
+  expect(hi).toBeCloseTo(20 + eps, 9);
 });
 
 test("passes non-numeric (e.g. Date) domains through untouched", () => {

--- a/tests/domain.test.js
+++ b/tests/domain.test.js
@@ -26,12 +26,22 @@ test("widens equal endpoints by eps", () => {
   expect(hi).toBeCloseTo(20 + eps, 9);
 });
 
-test("passes non-numeric (e.g. Date) domains through untouched", () => {
-  const d = [new Date(2020, 0, 1), new Date(2020, 1, 1)];
-  expect(normalizeDomain(d)).toBe(d);
-});
-
 test("passes through malformed input", () => {
   expect(normalizeDomain(null)).toBe(null);
-  expect(normalizeDomain([1])).toEqual([1]);
+  expect(normalizeDomain([1])).toEqual(null);
+});
+
+test("swaps reversed endpoints date", () => {
+  let domain = normalizeDomain([new Date("2026-3-1"), new Date("2026-2-1")],
+      [new Date("2026-1-1"), new Date("2026-4-1")]);
+  expect(domain).toEqual([new Date("2026-2-1"), new Date("2026-3-1")]);
+});
+
+test("widens equal endpoints by eps DATE", () => {
+  let eps = 1e-6;
+  const [lo, hi] = normalizeDomain([new Date("2026-3-1"), new Date("2026-3-1")],
+      [new Date("2026-1-1"), new Date("2026-4-1")], {eps: eps});
+  expect(lo).toEqual(new Date("2026-3-1"));
+  let diff = Math.abs(hi - new Date(new Date("2026-3-1").getTime() + eps));
+  expect(diff).toBeLessThanOrEqual(100);
 });

--- a/tests/domain.test.js
+++ b/tests/domain.test.js
@@ -11,9 +11,9 @@ test("swaps reversed endpoints", () => {
 test("Values outside the extend", () => {
   let eps = 1e-6;
   expect(normalizeDomain([10, 40], [20, 30],)).toEqual([20, 30]);
-  let [lo, hi] = normalizeDomain([40, 50], [20, 30], {eps: eps});
-  expect(hi).toBe(30);
-  expect(lo).toBeCloseTo(30 - eps, 9);
+  let [lo, hi] = normalizeDomain([40, 50], [30, 40], {eps: eps});
+  expect(hi).toBe(40);
+  expect(lo).toBeCloseTo(40 - eps, 9);
   [lo, hi] = normalizeDomain([10, 20], [20, 30], {eps: eps});
   expect(hi).toBeCloseTo(20 + eps, 9);
   expect(lo).toBe(20);

--- a/tests/domain.test.js
+++ b/tests/domain.test.js
@@ -1,0 +1,25 @@
+import { normalizeDomain } from "../src/utils.js";
+
+test("passes through an already-valid numeric domain", () => {
+  expect(normalizeDomain([10, 40])).toEqual([10, 40]);
+});
+
+test("swaps reversed endpoints", () => {
+  expect(normalizeDomain([40, 10])).toEqual([10, 40]);
+});
+
+test("widens equal endpoints by eps", () => {
+  const [lo, hi] = normalizeDomain([20, 20], { eps: 1e-6 });
+  expect(lo).toBe(20);
+  expect(hi).toBeCloseTo(20 + 1e-6, 9);
+});
+
+test("passes non-numeric (e.g. Date) domains through untouched", () => {
+  const d = [new Date(2020, 0, 1), new Date(2020, 1, 1)];
+  expect(normalizeDomain(d)).toBe(d);
+});
+
+test("passes through malformed input", () => {
+  expect(normalizeDomain(null)).toBe(null);
+  expect(normalizeDomain([1])).toEqual([1]);
+});


### PR DESCRIPTION
Implements #62. Makes the x-domain settable after creation (symmetry with y), adds ts.fullExtent and ts.setDomains({x,y}) (re-renders in place via ts.update(), preserving brushes). New jest test for normalizeDomain; BVH suite stays green. Per project policy this targets main via PR for @ivelascog to validate — do not self-merge.