### PR TITLE
feat: duplicate the current brush group (ts.duplicateSelectedGroup)

### DIFF
--- a/src/BrushInteraction.js
+++ b/src/BrushInteraction.js
@@ -702,6 +702,22 @@ function brushInteraction({
     updateGroups();
   };
 
+  me.duplicateBrushGroup = function (sourceId = brushGroupSelected) {
+    const source = brushesGroup.get(sourceId);
+    if (!source) return;
+    const payload = cloneBrushGroupPayload(source);
+    if (payload.brushes.length === 0) {
+      me.addBrushGroup(); // nothing committed → behave like Add Group
+      return;
+    }
+    const before = new Set(brushesGroup.keys());
+    me.addFilters([payload], false); // appends a new group, materializes copied brushes
+    const newId = [...brushesGroup.keys()].find((k) => !before.has(k));
+    if (newId !== undefined) selectBrushGroup(newId);
+    updateStatus();
+    updateGroups();
+  };
+
   me.changeBrushGroupState = function (id, newState) {
     if (brushesGroup.get(id).isEnable === newState) return; //same state so no update needed
 
@@ -1071,6 +1087,29 @@ function brushInteraction({
   drawBrushes();
 
   return me;
+}
+
+// Pure: build the payload that me.addFilters() consumes, from a brush group's
+// committed brushes (those with a non-null selection). No d3/DOM references.
+export function cloneBrushGroupPayload(group, { suffix = " (copy)" } = {}) {
+  const brushes = [];
+  if (group && group.brushes) {
+    for (const brush of group.brushes.values()) {
+      if (brush.selection !== null && brush.selectionDomain) {
+        brushes.push({
+          mode: brush.mode,
+          aggregation: brush.aggregation,
+          selectionDomain: brush.selectionDomain,
+        });
+      }
+    }
+  }
+  return {
+    isEnable: true,
+    isActive: false,
+    name: ((group && group.name) || "Group") + suffix,
+    brushes,
+  };
 }
 
 export default brushInteraction;

--- a/src/TimeWidget.js
+++ b/src/TimeWidget.js
@@ -223,11 +223,15 @@ function TimeWidget(
     <div id="brushesList">
     </div>
     <button id="btnAddBrushGroup">Add Group</button>
+    <button id="btnDuplicateBrushGroup">Duplicate Group</button>
     </div>`;
 
     groupsElement
       .querySelector("button#btnAddBrushGroup")
       .addEventListener("click", onAddBrushGroup);
+    groupsElement
+      .querySelector("button#btnDuplicateBrushGroup")
+      .addEventListener("click", onDuplicateBrushGroup);
 
     if (showBrushesControls) {
       d3.select(groupsElement).insert("h3", ":first-child").text("Groups:");
@@ -241,6 +245,10 @@ function TimeWidget(
 
   function onAddBrushGroup() {
     brushes.addBrushGroup();
+  }
+
+  function onDuplicateBrushGroup() {
+    brushes.duplicateBrushGroup();
   }
 
   function onChangeNonSelected(newState) {
@@ -1472,6 +1480,11 @@ function TimeWidget(
         init();
         brushes.addFilters(status, true);
     };
+
+  ts.duplicateSelectedGroup = () => {
+    brushes.duplicateBrushGroup();
+    return ts;
+  };
 
   // Remove possible previous event listener
   //target.removeEventListener("TimeWidget", onTimeWidgetEvent);

--- a/tests/brushGroup.test.js
+++ b/tests/brushGroup.test.js
@@ -1,0 +1,35 @@
+import { cloneBrushGroupPayload } from "../src/BrushInteraction.js";
+
+function fakeGroup() {
+  const brushes = new Map();
+  brushes.set(0, { mode: "Intersect", aggregation: "And", selection: [[0, 0], [10, 10]], selectionDomain: [[30, 1000], [40, 3000]] });
+  brushes.set(1, { mode: "Intersect", aggregation: "And", selection: null, selectionDomain: null }); // pending brush
+  return { name: "Group 1", isEnable: true, isActive: false, brushes };
+}
+
+test("copies only committed brushes with mode/aggregation/selectionDomain", () => {
+  const payload = cloneBrushGroupPayload(fakeGroup());
+  expect(payload.brushes).toEqual([
+    { mode: "Intersect", aggregation: "And", selectionDomain: [[30, 1000], [40, 3000]] },
+  ]);
+});
+
+test("appends a copy suffix to the name and is enabled, not active", () => {
+  const payload = cloneBrushGroupPayload(fakeGroup());
+  expect(payload.name).toBe("Group 1 (copy)");
+  expect(payload.isEnable).toBe(true);
+  expect(payload.isActive).toBe(false);
+});
+
+test("returns an empty brushes array for a group with no committed brushes", () => {
+  const brushes = new Map();
+  brushes.set(0, { mode: "Intersect", aggregation: "And", selection: null, selectionDomain: null });
+  const payload = cloneBrushGroupPayload({ name: "Group 2", brushes });
+  expect(payload.brushes).toEqual([]);
+});
+
+test("does not share the source Map reference", () => {
+  const g = fakeGroup();
+  const payload = cloneBrushGroupPayload(g);
+  expect(Array.isArray(payload.brushes)).toBe(true);
+});


### PR DESCRIPTION
Implements #61. Adds cloneBrushGroupPayload (pure) + me.duplicateBrushGroup (reuses addFilters) + ts.duplicateSelectedGroup() and a Duplicate Group button. New jest test for cloneBrushGroupPayload; BVH suite stays green. Per project policy this targets main via PR for @ivelascog to validate — do not self-merge.