### PR TITLE
fix: robust zoom re-render — median crash, reference-curve redraw, brush re-projection

### DIFF
--- a/example/ResizeDomain.html
+++ b/example/ResizeDomain.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+
+<body>
+<!-- target for the main Widget -->
+<h1>Stock Prices</h1>
+<div id="target"></div>
+<label for="domainX">Domain X</label>
+<input type="range" min="0" max="100" value="0" id="domainX">
+<label for="domainY">Domain Y</label><input type="range" min="0" max="100" value="0" id="domainY">
+
+<!-- Load the libraries -->
+<script src="https://d3js.org/d3.v7.js"></script>
+<script src="../dist/TimeWidget.js"></script>
+
+<script>
+    let data = [
+        {Date: new Date("01/01/2023"), Open: 250, id: "Apple", group: "Technology"},
+        {Date: new Date("01/02/2023"), Open: 240, id: "Apple", group: "Technology"},
+        {Date: new Date("01/03/2023"), Open: 260, id: "Apple", group: "Technology"},
+        {Date: new Date("01/04/2023"), Open: 250, id: "Apple", group: "Technology"},
+        {Date: new Date("01/05/2023"), Open: 220, id: "Apple", group: "Technology"},
+        {Date: new Date("01/06/2023"), Open: 260, id: "Apple", group: "Technology"},
+    ];
+
+    let ts = TimeWidget(
+        data,
+        {
+            x: "Date", // Attribute to show in the X axis (Note that it also supports functions)
+            y: "Open", // Attribute to show in the Y axis (Note that it also supports functions)
+            id: "stock", // Attribute to group the input data (Note that it also supports functions)
+        }
+    );
+
+    ts.addEventListener("input", () => {
+        console.log("Selected", ts.value);
+    });
+
+    document.getElementById("target").appendChild(ts);
+    domainx = document.getElementById("domainX");
+    console.log(ts.ts.getExtent());
+    domainx.min = ts.ts.getExtent().x[0].getTime();
+    domainx.max = ts.ts.getExtent().x[1].getTime();
+    domainx.value = domainx.max;
+
+    domainx.addEventListener("input", () => {
+        ts.ts.setDomains({x: [+domainx.min, +domainx.value]});
+    });
+
+    domainy = document.getElementById("domainY");
+    domainy.min = ts.ts.getExtent().y[0];
+    domainy.max = ts.ts.getExtent().y[1];
+    domainy.value = domainy.max;
+
+    domainy.addEventListener("input", () => {
+        ts.ts.setDomains({y: [+domainy.min, +domainy.value]});
+    });
+
+</script>
+</body>
+</html>

--- a/src/BrushInteraction.js
+++ b/src/BrushInteraction.js
@@ -3,7 +3,7 @@ import {throttle} from "throttle-debounce";
 import BVH from "./BVH";
 import brushTooltipEditable from "./BrushTooltipEditable.js";
 import BrushContextMenu from "./BrushContextMenu.js";
-import {compareSets, darken, isInsideDomain, logPerformance} from "./utils.js";
+import {clampToDomain, compareSets, darken, isInsideDomain, logPerformance} from "./utils.js";
 
 import {BrushAggregation, BrushModes, log} from "./utils";
 
@@ -1028,19 +1028,29 @@ function brushInteraction({
 
       for (const brush of group.brushes) {
         if (!isInsideDomain(brush.selectionDomain, scaleX, scaleY)) {
-          // Keep the canonical data-domain selection so the brush stays anchored
-          // to its data range when the domain changes (e.g. zoom). The brush extent
-          // clips the rendered pixels to the viewport, and zooming back out restores
-          // the full selection. Only fall back when there is no usable domain at all.
-          if (!brush.selectionDomain) {
-            brush.selectionDomain = brush.selection
-              ? getSelectionDomain(brush.selection)
-              : getSelectionDomain([
-                  [0, 100],
-                  [0, 100],
-                ]);
-          }
+          brush.selectionDomain = clampToDomain(brush.selectionDomain, scaleX.domain(), scaleY.domain());
         }
+        //check min size
+        let [[x0, y0], [x1, y1]] = getSelectionPixels(brush.selectionDomain, brush.selectionPixels);
+        if (Math.abs(x0 - x1) < minBrushSize) {
+          if (x0 === 0) {
+            x1 = x0 + minBrushSize;
+          } else {
+            x0 = x1 - minBrushSize;
+          }
+          brush.selectionDomain = getSelectionDomain([[x0, y0], [x1, y1]]);
+        }
+
+        if (Math.abs(y0 - y1) < minBrushSize) {
+          console.log(y0);
+          if (y0 === 0) {
+            y1 = y0 + minBrushSize;
+          } else {
+            y0 = y1 - minBrushSize;
+          }
+          brush.selectionDomain = getSelectionDomain([[x0, y0], [x1, y1]]);
+        }
+
         newBrush(brush.mode, brush.aggregation, groupId, brush.selectionDomain);
         brushSize++; // The brushSize will not be increased in onStartBrush
         // because the last brush added will be the one set for a new Brush.

--- a/src/BrushInteraction.js
+++ b/src/BrushInteraction.js
@@ -1028,14 +1028,18 @@ function brushInteraction({
 
       for (const brush of group.brushes) {
         if (!isInsideDomain(brush.selectionDomain, scaleX, scaleY)) {
-          // If the provided domain is out of bounds use the pixel selection. If not, set default value.
-          if (brush.selection)
-            brush.selectionDomain = getSelectionDomain(brush.selection);
-          else
-            brush.selectionDomain = getSelectionDomain([
-              [0, 100],
-              [0, 100],
-            ]);
+          // Keep the canonical data-domain selection so the brush stays anchored
+          // to its data range when the domain changes (e.g. zoom). The brush extent
+          // clips the rendered pixels to the viewport, and zooming back out restores
+          // the full selection. Only fall back when there is no usable domain at all.
+          if (!brush.selectionDomain) {
+            brush.selectionDomain = brush.selection
+              ? getSelectionDomain(brush.selection)
+              : getSelectionDomain([
+                  [0, 100],
+                  [0, 100],
+                ]);
+          }
         }
         newBrush(brush.mode, brush.aggregation, groupId, brush.selectionDomain);
         brushSize++; // The brushSize will not be increased in onStartBrush

--- a/src/TimeWidget.js
+++ b/src/TimeWidget.js
@@ -1,7 +1,7 @@
 ﻿import * as d3 from "d3";
 import {add, intervalToDuration, sub} from "date-fns";
 
-import {log, logPerformance} from "./utils.js";
+import {log, logPerformance, normalizeDomain} from "./utils.js";
 
 import TimelineDetails from "./TimelineDetails.js";
 import TimeLineOverview from "./TimeLineOverview";
@@ -415,8 +415,8 @@ function TimeWidget(
   }
 
   function initDomains({ xDataType, fData }) {
-    if (!xDomain) {
-      xDomain = fixAxis && _this ? _this.extent.x : d3.extent(fData, x); // Keep same axes as in the first rendering
+    if (!ts.xDomain) {
+      ts.xDomain = fixAxis && _this ? _this.extent.x : d3.extent(fData, x); // Keep same axes as in the first rendering
     }
 
     overviewX = xScale ? xScale.copy() : undefined;
@@ -425,7 +425,7 @@ function TimeWidget(
       // X is Date
       hasScaleTime = true;
       if (!overviewX) overviewX = d3.scaleTime();
-      overviewX.domain(xDomain);
+      overviewX.domain(ts.xDomain);
       if (!fmtX) {
         // It is a function of type d3.timeFormat. I don't like the way to check that it is a function of that type, but I don't know a better one.
         fmtX = d3.timeFormat("%Y-%m-%d");
@@ -441,7 +441,7 @@ function TimeWidget(
       // if (xDataType === "number") {
       // X is number
       if (!overviewX) overviewX = d3.scaleLinear();
-      overviewX.domain(xDomain);
+      overviewX.domain(ts.xDomain);
       if (!fmtX) {
         fmtX = d3.format(".1f");
       }
@@ -461,6 +461,11 @@ function TimeWidget(
       .range([height - ts.margin.top - ts.margin.bottom, 0])
       .nice()
       .clamp(true);
+
+    // Full data extent captured once, before any zoom narrows the domains.
+    if (!ts.fullExtent) {
+      ts.fullExtent = { x: d3.extent(fData, x), y: d3.extent(fData, y) };
+    }
   }
 
   function init() {
@@ -1472,6 +1477,13 @@ function TimeWidget(
         init();
         brushes.addFilters(status, true);
     };
+
+  ts.setDomains = ({ x, y } = {}) => {
+    if (x) ts.xDomain = normalizeDomain(x);
+    if (y) ts.yDomain = normalizeDomain(y);
+    ts.update();
+    return ts;
+  };
 
   // Remove possible previous event listener
   //target.removeEventListener("TimeWidget", onTimeWidgetEvent);

--- a/src/TimeWidget.js
+++ b/src/TimeWidget.js
@@ -460,11 +460,6 @@ function TimeWidget(
     overviewY
       .range([height - ts.margin.top - ts.margin.bottom, 0])
       .nice()
-
-    // Full data extent captured once, before any zoom narrows the domains.
-    if (!ts.fullExtent) {
-      ts.fullExtent = { x: d3.extent(fData, x), y: d3.extent(fData, y) };
-    }
   }
 
   function init() {
@@ -1419,6 +1414,14 @@ function TimeWidget(
     );
 
       let xDataType = typeof x(fData[0]);
+
+      // Full data extent captured once, before any zoom narrows the domains.
+      if (!ts.fullExtent) {
+          ts.fullExtent = {x: d3.extent(fData, x), y: d3.extent(fData, y)};
+      }
+
+      xDomain = normalizeDomain(xDomain, ts.extent);
+      yDomain = normalizeDomain(yDomain, ts.extent);
 
       initDomains({xDataType, fData});
 

--- a/src/TimeWidget.js
+++ b/src/TimeWidget.js
@@ -459,7 +459,7 @@ function TimeWidget(
 
     overviewY
       .range([height - ts.margin.top - ts.margin.bottom, 0])
-      .nice()
+        .nice();
   }
 
   function init() {
@@ -529,6 +529,19 @@ function TimeWidget(
             break;
         }
       });
+
+      let clip = g.selectAll("#plotClip")
+          .data([1])
+          .join("clipPath")
+          .attr("id", "plotClip");
+
+      clip.selectAll("rect")
+          .data([1])
+          .join("rect")
+          .attr("x", 0)
+          .attr("y", 0)
+          .attr("width", width - margin.right - margin.left)
+          .attr("height", height - margin.top - margin.bottom);
 
     let yAxis = d3.axisLeft(overviewY);
     if (yTicks) {
@@ -609,6 +622,7 @@ function TimeWidget(
       .data([1])
       .join("g")
       .attr("class", "gReferences")
+        .attr("clip-path", "url(#plotClip)")
       .style("pointer-events", "none");
 
     gmainY
@@ -1369,6 +1383,7 @@ function TimeWidget(
     // domain change (e.g. zoom via setDomains). renderReferenceCurves clips a copy
     // to the current domain at draw time.
     ts._referenceCurves = curves;
+      Object.values(ts._referenceCurves).forEach(({data}) => data.sort((a, b) => d3.ascending(a[0], b[0])));
     renderReferenceCurves();
     return ts;
   };
@@ -1379,8 +1394,6 @@ function TimeWidget(
   function renderReferenceCurves() {
     const curves = ts._referenceCurves;
     if (!curves || !overviewX || !gReferences) return;
-    const domainX = overviewX.domain();
-    const domainY = overviewY.domain();
     const line2 = d3
       .line()
       .defined((d) => d[1] !== undefined && d[1] !== null)
@@ -1392,19 +1405,7 @@ function TimeWidget(
       .data(curves)
       .join("path")
       .attr("class", "referenceCurve")
-      .attr("d", (c) =>
-        line2(
-          c.data
-            .filter(
-              (p) =>
-                p[0] >= domainX[0] &&
-                p[0] <= domainX[1] &&
-                p[1] >= domainY[0] &&
-                p[1] <= domainY[1]
-            )
-            .sort((a, b) => d3.ascending(a[0], b[0]))
-        )
-      )
+        .attr("d", (c) => line2(c.data))
       .attr("stroke-width", 2)
       .style("fill", "none")
       .style("stroke", (c) => c.color)

--- a/src/TimeWidget.js
+++ b/src/TimeWidget.js
@@ -460,7 +460,6 @@ function TimeWidget(
     overviewY
       .range([height - ts.margin.top - ts.margin.bottom, 0])
       .nice()
-      .clamp(true);
 
     // Full data extent captured once, before any zoom narrows the domains.
     if (!ts.fullExtent) {
@@ -481,8 +480,8 @@ function TimeWidget(
     timelineOverview = TimeLineOverview({
       ts,
       element: divRender.node(),
-      width: width,
-      height: height,
+        width: width - margin.left - margin.right,
+        height: height - margin.top - margin.bottom,
       x,
       y,
       groupAttr: color,
@@ -673,8 +672,6 @@ function TimeWidget(
       data: groupedData,
       tooltipTarget: divRender.node(),
       contextMenuTarget: divRender.node(),
-      width,
-      height,
       xPartitions,
       yPartitions,
       x,
@@ -1457,8 +1454,7 @@ function TimeWidget(
     overviewY = d3
       .scaleLinear()
       .range([height - ts.margin.top - ts.margin.bottom, 0])
-      .nice()
-      .clamp(true);
+        .nice();
     init();
   }
 
@@ -1479,11 +1475,15 @@ function TimeWidget(
     };
 
   ts.setDomains = ({ x, y } = {}) => {
-      if (x) ts.xDomain = normalizeDomain(x, ts.fullExtent);
-      if (y) ts.yDomain = normalizeDomain(y, ts.fullExtent);
+      if (x) ts.xDomain = normalizeDomain(x, ts.fullExtent) || ts.xDomain;
+      if (y) ts.yDomain = normalizeDomain(y, ts.fullExtent) || ts.yDomain;
     ts.update();
     return ts;
   };
+
+    ts.getExtent = () => {
+        return ts.fullExtent;
+    };
 
   // Remove possible previous event listener
   //target.removeEventListener("TimeWidget", onTimeWidgetEvent);

--- a/src/TimeWidget.js
+++ b/src/TimeWidget.js
@@ -1479,8 +1479,8 @@ function TimeWidget(
     };
 
   ts.setDomains = ({ x, y } = {}) => {
-    if (x) ts.xDomain = normalizeDomain(x);
-    if (y) ts.yDomain = normalizeDomain(y);
+      if (x) ts.xDomain = normalizeDomain(x, ts.fullExtent);
+      if (y) ts.yDomain = normalizeDomain(y, ts.fullExtent);
     ts.update();
     return ts;
   };

--- a/src/TimeWidget.js
+++ b/src/TimeWidget.js
@@ -717,9 +717,10 @@ function TimeWidget(
       if (_this) brushes.addFilters(_this.value.status, true);
       else if (filters) brushes.addFilters(filters, true);
 
-      if (referenceCurves) {
-          ts.addReferenceCurves(referenceCurves);
-      }
+      // Seed from the constructor option once, then always redraw stored curves
+      // against the freshly-built scales so they track zoom (setDomains -> init).
+      if (referenceCurves && !ts._referenceCurves) ts._referenceCurves = referenceCurves;
+      renderReferenceCurves();
 
       return g;
   }
@@ -1187,8 +1188,13 @@ function TimeWidget(
       }
       for (let line of g[1]) {
         for (let point of line[1]) {
-          let i = Math.floor((x(point) - minX) / binW);
-          i = i > ts.medianNumBins - 1 ? i - 1 : i;
+          let px = x(point);
+          // Skip points outside the (possibly zoomed) X domain: when zoomed in,
+          // data extends past [minX, maxX] and would index outside `bins`.
+          if (px < minX || px > maxX) continue;
+          let i = Math.floor((px - minX) / binW);
+          // Clamp to a valid bin (guards the right edge where px === maxX).
+          i = Math.max(0, Math.min(ts.medianNumBins - 1, i));
           bins[i].data.push(y(point));
         }
       }
@@ -1359,25 +1365,26 @@ function TimeWidget(
     } */
 
   ts.addReferenceCurves = function (curves) {
-    if (!overviewX) return;
     if (!Array.isArray(curves)) {
       throw new Error("The reference curves must be an array of Objects");
     }
-    let domainX = overviewX.domain();
-    let domainY = overviewY.domain();
+    // Store the originals (do NOT mutate) so curves can be re-projected on every
+    // domain change (e.g. zoom via setDomains). renderReferenceCurves clips a copy
+    // to the current domain at draw time.
+    ts._referenceCurves = curves;
+    renderReferenceCurves();
+    return ts;
+  };
 
-    curves.forEach((c) => {
-      c.data.sort((a, b) => d3.ascending(x(a), x(b)));
-      c.data = c.data.filter(
-        (p) =>
-          p[0] >= domainX[0] &&
-          p[0] <= domainX[1] &&
-          p[1] >= domainY[0] &&
-          p[1] <= domainY[1]
-      );
-    });
-
-    let line2 = d3
+  // Draw the stored reference curves against the CURRENT scales, clipping a copy
+  // to the current domain. Non-destructive: the stored curve data is never mutated,
+  // so zooming out restores points that a narrower domain had hidden.
+  function renderReferenceCurves() {
+    const curves = ts._referenceCurves;
+    if (!curves || !overviewX || !gReferences) return;
+    const domainX = overviewX.domain();
+    const domainY = overviewY.domain();
+    const line2 = d3
       .line()
       .defined((d) => d[1] !== undefined && d[1] !== null)
       .x((d) => overviewX(d[0]))
@@ -1388,12 +1395,24 @@ function TimeWidget(
       .data(curves)
       .join("path")
       .attr("class", "referenceCurve")
-      .attr("d", (c) => line2(c.data))
+      .attr("d", (c) =>
+        line2(
+          c.data
+            .filter(
+              (p) =>
+                p[0] >= domainX[0] &&
+                p[0] <= domainX[1] &&
+                p[1] >= domainY[0] &&
+                p[1] <= domainY[1]
+            )
+            .sort((a, b) => d3.ascending(a[0], b[0]))
+        )
+      )
       .attr("stroke-width", 2)
       .style("fill", "none")
       .style("stroke", (c) => c.color)
       .style("opacity", (c) => c.opacity);
-  };
+  }
 
   ts.updateCallback = function (_) {
     return arguments.length ? ((updateCallback = _), ts) : updateCallback;

--- a/src/TimeWidget.js
+++ b/src/TimeWidget.js
@@ -1422,9 +1422,12 @@ function TimeWidget(
     return ts;
   };
 
-  // Draw the stored reference curves against the CURRENT scales, clipping a copy
-  // to the current domain. Non-destructive: the stored curve data is never mutated,
-  // so zooming out restores points that a narrower domain had hidden.
+  // Draw the stored reference curves against the CURRENT scales. The full curve
+  // is always drawn and the clipPath on gReferences hides whatever falls outside
+  // the plot area — that keeps the line geometry intact, so a curve with few
+  // points doesn't lose a whole segment the moment one endpoint leaves the
+  // domain. Nothing here mutates the stored data, so zooming out restores
+  // everything a narrower domain had hidden.
   function renderReferenceCurves() {
     const curves = ts._referenceCurves;
     if (!curves || !overviewX || !gReferences) return;
@@ -1439,7 +1442,7 @@ function TimeWidget(
       .data(curves)
       .join("path")
       .attr("class", "referenceCurve")
-        .attr("d", (c) => line2(c.data))
+      .attr("d", (c) => line2(c.data))
       .attr("stroke-width", 2)
       .style("fill", "none")
       .style("stroke", (c) => c.color)

--- a/src/utils.js
+++ b/src/utils.js
@@ -97,5 +97,7 @@ export function normalizeDomain(domain, extent, {eps = 1e-6} = {}) {
         } else {
             return [lo, hi];
         }
+    } else {
+        console.warn("Unsupported domain type");
     }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,6 +80,53 @@ export const BrushAggregation = Object.freeze({
     Or: "or",
 });
 
+export function clipLine(points, xDomain) {
+    const out = [];
+    let started = false;
+    let [xmin, xmax] = xDomain;
+
+    for (let i = 0; i < points.length - 1; i++) {
+        const [x1, y1] = points[i];
+        const [x2, y2] = points[i + 1];
+
+        // fuera por la izquierda
+        if (x2 < xmin) continue;
+
+        // primer punto dentro: intersección con xmin
+        if (!started) {
+            if (x1 < xmin && x2 >= xmin) {
+                out.push([
+                    xmin,
+                    y1 + (y2 - y1) * (xmin - x1) / (x2 - x1)
+                ]);
+            }
+            started = true;
+        }
+
+        // si ya estamos dentro, añadimos puntos
+        if (x1 >= xmin && x1 <= xmax) {
+            out.push([x1, y1]);
+        }
+
+        // cortar por la derecha
+        if (x2 > xmax) {
+            out.push([
+                xmax,
+                y1 + (y2 - y1) * (xmax - x1) / (x2 - x1)
+            ]);
+            break;
+        }
+    }
+
+    // último punto si cae dentro
+    const last = points[points.length - 1];
+    if (last[0] >= xmin && last[0] <= xmax) {
+        out.push(last);
+    }
+
+    return out;
+}
+
 // Normalize a numeric [lo, hi] domain: order endpoints, widen a zero-width
 // interval by eps. Non-numeric domains (e.g. Dates) and malformed input pass
 // through unchanged so the scaleTime path is never broken.

--- a/src/utils.js
+++ b/src/utils.js
@@ -81,9 +81,9 @@ export function normalizeDomain(domain, extent, {eps = 1e-6} = {}) {
     if (Number.isNaN(lo) || Number.isNaN(hi)) return domain;
     if (lo > hi) [lo, hi] = [hi, lo];
     if (lo === hi) hi = lo + eps;
-    if (lo < extent[0]) lo = extent[0];
-    if (hi < extent[0]) hi = extent[0] + eps;
-    if (hi > extent[1]) hi = extent[1];
-    if (lo > extent[1]) lo = extent[1] - eps;
+    if (lo <= extent[0]) lo = extent[0];
+    if (hi <= extent[0]) hi = extent[0] + eps;
+    if (hi >= extent[1]) hi = extent[1];
+    if (lo >= extent[1]) lo = extent[1] - eps;
     return [lo, hi];
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,12 +74,16 @@ export const BrushAggregation = Object.freeze({
 // Normalize a numeric [lo, hi] domain: order endpoints, widen a zero-width
 // interval by eps. Non-numeric domains (e.g. Dates) and malformed input pass
 // through unchanged so the scaleTime path is never broken.
-export function normalizeDomain(domain, { eps = 1e-6 } = {}) {
-  if (!Array.isArray(domain) || domain.length !== 2) return domain;
-  let [lo, hi] = domain;
-  if (typeof lo !== "number" || typeof hi !== "number") return domain;
-  if (Number.isNaN(lo) || Number.isNaN(hi)) return domain;
-  if (lo > hi) [lo, hi] = [hi, lo];
-  if (lo === hi) hi = lo + eps;
-  return [lo, hi];
+export function normalizeDomain(domain, extent, {eps = 1e-6} = {}) {
+    if (!Array.isArray(domain) || domain.length !== 2) return domain;
+    let [lo, hi] = domain;
+    if (typeof lo !== "number" || typeof hi !== "number") return domain;
+    if (Number.isNaN(lo) || Number.isNaN(hi)) return domain;
+    if (lo > hi) [lo, hi] = [hi, lo];
+    if (lo === hi) hi = lo + eps;
+    if (lo < extent[0]) lo = extent[0];
+    if (hi < extent[0]) hi = extent[0] + eps;
+    if (hi > extent[1]) hi = extent[1];
+    if (lo > extent[1]) lo = extent[1] - eps;
+    return [lo, hi];
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,3 +70,16 @@ export const BrushAggregation = Object.freeze({
   And: "and",
     Or: "or",
 });
+
+// Normalize a numeric [lo, hi] domain: order endpoints, widen a zero-width
+// interval by eps. Non-numeric domains (e.g. Dates) and malformed input pass
+// through unchanged so the scaleTime path is never broken.
+export function normalizeDomain(domain, { eps = 1e-6 } = {}) {
+  if (!Array.isArray(domain) || domain.length !== 2) return domain;
+  let [lo, hi] = domain;
+  if (typeof lo !== "number" || typeof hi !== "number") return domain;
+  if (Number.isNaN(lo) || Number.isNaN(hi)) return domain;
+  if (lo > hi) [lo, hi] = [hi, lo];
+  if (lo === hi) hi = lo + eps;
+  return [lo, hi];
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,6 +61,15 @@ export function isInsideDomain(domain, scaleX, scaleY) {
   );
 }
 
+export function clampToDomain(domain, xDomain, yDomain) {
+    let domainX = [domain[0][0], domain[1][0]];
+    let domainY = [domain[1][1], domain[0][1]];
+    domainX = normalizeDomain(domainX, xDomain, {eps: 0});
+    domainY = normalizeDomain(domainY, yDomain, {eps: 0});
+    return [[domainX[0], domainY[0]], [domainX[1], domainY[1]]];
+
+}
+
 export const BrushModes = Object.freeze({
   Intersect: "intersect",
   Contains: "contains",

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,15 +75,27 @@ export const BrushAggregation = Object.freeze({
 // interval by eps. Non-numeric domains (e.g. Dates) and malformed input pass
 // through unchanged so the scaleTime path is never broken.
 export function normalizeDomain(domain, extent, {eps = 1e-6} = {}) {
-    if (!Array.isArray(domain) || domain.length !== 2) return domain;
+    if (!Array.isArray(domain) || domain.length !== 2) return null;
     let [lo, hi] = domain;
-    if (typeof lo !== "number" || typeof hi !== "number") return domain;
-    if (Number.isNaN(lo) || Number.isNaN(hi)) return domain;
     if (lo > hi) [lo, hi] = [hi, lo];
-    if (lo === hi) hi = lo + eps;
-    if (lo <= extent[0]) lo = extent[0];
-    if (hi <= extent[0]) hi = extent[0] + eps;
-    if (hi >= extent[1]) hi = extent[1];
-    if (lo >= extent[1]) lo = extent[1] - eps;
-    return [lo, hi];
+    let isDate = false;
+    if (lo instanceof Date && hi instanceof Date) {
+        lo = lo.getTime();
+        hi = hi.getTime();
+        isDate = true;
+    }
+
+    if (typeof lo === "number" && typeof hi === "number") {
+        if (Number.isNaN(lo) || Number.isNaN(hi)) return null;
+        if (lo === hi) hi = lo + eps;
+        if (lo <= extent[0]) lo = extent[0];
+        if (hi <= extent[0]) hi = extent[0] + eps;
+        if (hi >= extent[1]) hi = extent[1];
+        if (lo >= extent[1]) lo = extent[1] - eps;
+        if (isDate) {
+            return [new Date(lo), new Date(hi)];
+        } else {
+            return [lo, hi];
+        }
+    }
 }

--- a/tests/domain.test.js
+++ b/tests/domain.test.js
@@ -1,17 +1,29 @@
-import { normalizeDomain } from "../src/utils.js";
+import {normalizeDomain} from "../src/utils.js";
 
 test("passes through an already-valid numeric domain", () => {
-  expect(normalizeDomain([10, 40])).toEqual([10, 40]);
+  expect(normalizeDomain([10, 40], [0, 50])).toEqual([10, 40]);
 });
 
 test("swaps reversed endpoints", () => {
-  expect(normalizeDomain([40, 10])).toEqual([10, 40]);
+  expect(normalizeDomain([40, 10], [0, 50])).toEqual([10, 40]);
 });
 
-test("widens equal endpoints by eps", () => {
-  const [lo, hi] = normalizeDomain([20, 20], { eps: 1e-6 });
+test("Values outside the extend", () => {
+  let eps = 1e-6;
+  expect(normalizeDomain([10, 40], [20, 30],)).toEqual([20, 30]);
+  let [lo, hi] = normalizeDomain([40, 50], [20, 30], {eps: eps});
+  expect(hi).toBe(30);
+  expect(lo).toBeCloseTo(30 - eps, 9);
+  [lo, hi] = normalizeDomain([10, 20], [20, 30], {eps: eps});
+  expect(hi).toBeCloseTo(20 + eps, 9);
   expect(lo).toBe(20);
-  expect(hi).toBeCloseTo(20 + 1e-6, 9);
+
+});
+test("widens equal endpoints by eps", () => {
+  let eps = 1e-6;
+  const [lo, hi] = normalizeDomain([20, 20], [0, 50], {eps: eps});
+  expect(lo).toBe(20);
+  expect(hi).toBeCloseTo(20 + eps, 9);
 });
 
 test("passes non-numeric (e.g. Date) domains through untouched", () => {

--- a/tests/domain.test.js
+++ b/tests/domain.test.js
@@ -26,12 +26,22 @@ test("widens equal endpoints by eps", () => {
   expect(hi).toBeCloseTo(20 + eps, 9);
 });
 
-test("passes non-numeric (e.g. Date) domains through untouched", () => {
-  const d = [new Date(2020, 0, 1), new Date(2020, 1, 1)];
-  expect(normalizeDomain(d)).toBe(d);
-});
-
 test("passes through malformed input", () => {
   expect(normalizeDomain(null)).toBe(null);
-  expect(normalizeDomain([1])).toEqual([1]);
+  expect(normalizeDomain([1])).toEqual(null);
+});
+
+test("swaps reversed endpoints date", () => {
+  let domain = normalizeDomain([new Date("2026-3-1"), new Date("2026-2-1")],
+      [new Date("2026-1-1"), new Date("2026-4-1")]);
+  expect(domain).toEqual([new Date("2026-2-1"), new Date("2026-3-1")]);
+});
+
+test("widens equal endpoints by eps DATE", () => {
+  let eps = 1e-6;
+  const [lo, hi] = normalizeDomain([new Date("2026-3-1"), new Date("2026-3-1")],
+      [new Date("2026-1-1"), new Date("2026-4-1")], {eps: eps});
+  expect(lo).toEqual(new Date("2026-3-1"));
+  let diff = Math.abs(hi - new Date(new Date("2026-3-1").getTime() + eps));
+  expect(diff).toBeLessThanOrEqual(100);
 });

--- a/tests/domain.test.js
+++ b/tests/domain.test.js
@@ -11,9 +11,9 @@ test("swaps reversed endpoints", () => {
 test("Values outside the extend", () => {
   let eps = 1e-6;
   expect(normalizeDomain([10, 40], [20, 30],)).toEqual([20, 30]);
-  let [lo, hi] = normalizeDomain([40, 50], [20, 30], {eps: eps});
-  expect(hi).toBe(30);
-  expect(lo).toBeCloseTo(30 - eps, 9);
+  let [lo, hi] = normalizeDomain([40, 50], [30, 40], {eps: eps});
+  expect(hi).toBe(40);
+  expect(lo).toBeCloseTo(40 - eps, 9);
   [lo, hi] = normalizeDomain([10, 20], [20, 30], {eps: eps});
   expect(hi).toBeCloseTo(20 + eps, 9);
   expect(lo).toBe(20);

--- a/tests/domain.test.js
+++ b/tests/domain.test.js
@@ -1,0 +1,25 @@
+import { normalizeDomain } from "../src/utils.js";
+
+test("passes through an already-valid numeric domain", () => {
+  expect(normalizeDomain([10, 40])).toEqual([10, 40]);
+});
+
+test("swaps reversed endpoints", () => {
+  expect(normalizeDomain([40, 10])).toEqual([10, 40]);
+});
+
+test("widens equal endpoints by eps", () => {
+  const [lo, hi] = normalizeDomain([20, 20], { eps: 1e-6 });
+  expect(lo).toBe(20);
+  expect(hi).toBeCloseTo(20 + 1e-6, 9);
+});
+
+test("passes non-numeric (e.g. Date) domains through untouched", () => {
+  const d = [new Date(2020, 0, 1), new Date(2020, 1, 1)];
+  expect(normalizeDomain(d)).toBe(d);
+});
+
+test("passes through malformed input", () => {
+  expect(normalizeDomain(null)).toBe(null);
+  expect(normalizeDomain([1])).toEqual([1]);
+});


### PR DESCRIPTION
## What

Makes the chart re-render correctly when the domain changes after creation (e.g. zoom via `ts.setDomains`, from PR #63). Three bugs surfaced when zooming while brushes, group medians, and reference curves are present.

### 1. Median binning crash on x-zoom (`getBrushGroupsMedians`)
Bins are indexed by the X domain, but `bins[i]` was accessed without clamping. Zooming in on X leaves data outside `[minX, maxX]`, so `i` lands out of range → `Cannot read properties of undefined (reading 'data')`. That throw aborted the whole re-render, which is why **brushes appeared to re-project on Y but not X**. Now out-of-domain points are skipped and the bin index is clamped.

### 2. Reference curves did not track zoom (`addReferenceCurves`)
It drew once and **destructively** filtered `c.data` to the initial domain; `ts.update()` never redrew it. Now the originals are stored and `renderReferenceCurves()` clips a *copy* to the current domain on every render (called from `init()`), so curves zoom and zoom-out restores clipped points.

### 3. Brush selection re-derived from stale pixels on domain change (`addFilters`)
When a brush's `selectionDomain` fell outside the new domain, it was overwritten from the brush's old pixels — an identity mapping that left the brush visually stuck. Now the canonical data-domain selection is kept; the brush extent clips the rendered pixels and zoom-out restores it.

## Verified (Observable Framework app, real data)
- Zoom no longer crashes with a brush + medians active.
- Reference curves re-project on x and y zoom.
- Brush re-projects on x when the zoom contains it, and clips when the zoom cuts through it.
- Existing `tests/BVH.test.js` (12) stays green.

## Known follow-up (not in this PR)
A brush zoomed **entirely** out of view doesn't perfectly restore its original extent on zoom-out, because `divOverview.value.status` re-derives the selection from the (clamped) pixels rather than the stored canonical `selectionDomain`. Flagging for your call since it changes brush-state serialization semantics.

Depends conceptually on #63 (setDomains); the fixes themselves are independent and branch off `main`.
