### PR TITLE
test: add a playwright e2e layer for the zoom work, plus an agent guide

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,3 +29,28 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test
+
+  e2e:
+    # Drives the built bundle in a real browser. The unit suite cannot reach
+    # this layer: every bug fixed in #63/#65 was a call-site or render bug, and
+    # the suite stayed green at 19/19 while all of them were live.
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js 20.x
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20.x
+        cache: 'npm'
+    - run: npm ci
+    # The e2e suite loads dist/, so the bundle has to exist before it runs.
+    - run: npm run build
+    - run: npx playwright install --with-deps chromium
+    - run: npm run test:e2e
+    - uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,9 @@ dist
 .yarn/install-state.gz
 .pnp.*
 .DS_Store
+
+# Playwright e2e artifacts
+test-results/
+playwright-report/
+blob-report/
+.playwright-mcp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+This project's agent guide lives in **[CLAUDE.md](./CLAUDE.md)** — read it first.
+
+It is not Claude-specific: it covers what the project is, how to build/test/run
+it, the conventions that matter, and the traps that will otherwise cost you an
+afternoon (the pre-Babel acorn in the build, the inverted y convention in brush
+selections, the document-wide `clip-path` id).
+
+Quick reference:
+
+```bash
+npm ci
+npm run build      # required before e2e — the e2e suite drives dist/, not src/
+npm test           # jest unit tests
+npm run test:e2e   # playwright, real browser
+npm run test:all   # the full gate
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,164 @@
+# TimeWidget — agent guide
+
+An interactive **TimeSearcher** visualization: many time series drawn on one
+canvas, queried by dragging **TimeBoxes** (brushes) over regions of the plot.
+Vanilla JS + d3 v7, no framework. Published to npm as `time-widget`; consumed
+from a `<script>` tag, from Observable, or as an ESM import.
+
+Maintained by Iván Velasco González ([@ivelascog](https://github.com/ivelascog),
+repo owner) and John Alexis Guerra Gómez ([@john-guerra](https://github.com/john-guerra)).
+
+---
+
+## Build, test, run
+
+```bash
+npm ci
+npm run build          # rollup -> dist/{TimeWidget.js,.esm.js,.min.js}
+npm test               # jest unit tests (node env, native ESM)
+npm run test:e2e       # playwright, real browser, drives dist/
+npm run test:all       # unit -> build -> e2e, the full gate
+```
+
+To see it in a browser:
+
+```bash
+npx http-server . -p 8099 -c-1     # serve the REPO ROOT, not example/
+open http://localhost:8099/example/stocks.html
+```
+
+Serve the repo root: the examples load `../dist/TimeWidget.js`, and the e2e
+fixture also loads `../../node_modules/d3/dist/d3.js`. Only the root contains
+both. `npm run dev` is `rollup -c -w` — a watch build, **not** a server.
+
+**`npm run build` before e2e.** The e2e suite drives `dist/`, not `src/`, so a
+source edit is invisible to it until you rebuild. CI does this explicitly.
+
+### Which example to open
+
+| File | Good for |
+|---|---|
+| `example/stocks.html` | **default choice** — ~410 real series, brushes, medians, reference curves |
+| `example/ResizeDomain.html` | `ts.setDomains()` zoom, driven by sliders |
+| `example/canguro.html` | reference curves (growth charts) |
+| `example/minimum.html` | smallest possible embed |
+
+---
+
+## Architecture
+
+| File | Role |
+|---|---|
+| `src/TimeWidget.js` | the factory. Owns scales, layout, the `ts` API object, render orchestration. **~1500 lines — the file everything gets piled into; extract rather than append.** |
+| `src/BrushInteraction.js` | TimeBoxes: creation, drag, groups, filter logic, selection state |
+| `src/TimeLineOverview.js` | canvas rendering of the series + group medians |
+| `src/BVH.js` | bounding-volume hierarchy for hit-testing at scale |
+| `src/utils.js` | framework-free helpers — **the testable seam; put pure logic here** |
+
+`TimeWidget(data, opts)` returns a **DOM element** with the internal API hung
+off it as `element.ts`, plus `element.value`, `.brushGroups`, `.extent`. So
+`ts.ts.setDomains(...)` in example code is not a typo.
+
+Two names for one thing: `ts` (internal API object) vs the returned element.
+`let ts = {}` at the top of the factory is a **plain object**, not the element —
+assigning `ts.foo` does not put `foo` on the DOM node.
+
+---
+
+## Traps that will cost you an afternoon
+
+**The build parses with an ancient acorn, before Babel.**
+`rollup-plugin-ascii` bundles its own acorn that predates ES2018. `??`, `?.`,
+and object spread all fail at *bundle* time with a bare `SyntaxError: Unexpected
+token` — while `npm test` stays green, because jest never touches that parser.
+Use `||`, explicit null checks, `Object.assign`, and `.slice()`. Always run
+`npm run build` before believing a change works.
+
+**d3 is an `external`, not bundled.** `dist/TimeWidget.js` expects a global
+`d3`. Any host page must load d3 first.
+
+**`selectionDomain` is `[[xLow, yHigh], [xHigh, yLow]]`.**
+It comes from pixel corners `[[left, top], [right, bottom]]`, and `scaleY`'s
+range is `[height, 0]`, so the **top** pixel inverts to the **high** data value.
+The array order stays the same while the semantic order reverses. `isInsideDomain`
+and `clampToDomain` both encode this; a new helper that assumes ascending y will
+be subtly wrong. (`getSelectionDomain` / `getSelectionPixels` take **one**
+argument each.)
+
+**`rect.selection` matches d3's hidden pending brush too.** It has no
+`width`/`height` attributes. Filter for the one with real dimensions or you will
+measure the invisible one and conclude the brush is broken. (This cost an
+afternoon.)
+
+**d3 launders brush geometry.** `brush.move` normalises the extent and
+`newBrush()` stores `selectionDomain: null`, re-deriving it from the rendered
+pixels. So a wrong corner *order* coming out of `clampToDomain` is invisible in
+the DOM, and d3's `brush.extent` already confines pixels to the plot area. Test
+that contract at the **unit** level; an e2e assertion on the rendered rect will
+pass either way. See the note in `tests/e2e/zoom.spec.js`.
+
+**Zoom re-renders through `ts.update()`, never `ts.data()`.**
+`ts.update()` calls `initDomains()` + `init()`. `ts.data()` is only for a new
+dataset — that is why `fullExtent` can be recomputed there without a zoom
+narrowing it.
+
+**`clip-path="url(#id)"` resolves document-wide.** Unlike the repo's other DOM
+ids (`#render`, `#brushes`), which are only ever used as selectors scoped to a
+widget's own subtree, an SVG `url(#…)` reference is global. Two widgets on one
+page sharing an id means the second is clipped by the first one's rect. Hence
+`clipId = plotClip-${++instanceCounter}`, stable across re-renders.
+
+**Reference curves must not be mutated.** Store sorted *copies*
+(`storeReferenceCurves`). The original code filtered `c.data` down to the visible
+domain in place, so zooming out could never restore the discarded points.
+
+---
+
+## Conventions
+
+- **2-space indent, prettier + eslint.** `npm run build` does not lint, and
+  neither does CI; run `npx eslint src/` yourself. Six pre-existing
+  `no-unused-vars` errors are known (as of Aug 2026) — check whether a reported
+  error is actually yours before chasing it.
+- **Conventional commits** (`fix:`, `feat:`, `chore:`), and PRs are
+  **squash-merged**, so `main` stays linear.
+- **Squash-merging breaks ancestry.** `git branch --merged` will report a merged
+  branch as unmerged and `-d` will refuse it. Check content instead —
+  `git diff main <branch>` — before deleting, and use `-D`.
+- **`dist/` is gitignored** but published to npm; never commit build output.
+- Repo is `ivelascog/TimeWidget`; `origin` points there for both of us.
+
+---
+
+## Testing
+
+A real pyramid — put each test at the tier that can actually observe the bug.
+
+- **`tests/*.test.js`** — jest, node env, native ESM. Pure logic only. Note
+  `jest` is **not a global**: `import { jest } from "@jest/globals"`.
+- **`tests/e2e/*.spec.js`** — playwright against `dist/` via
+  `tests/e2e/fixture.html`, which exposes `window.makeWidget/makeData`. Build
+  widgets there rather than depending on `example/` pages, which change for demo
+  reasons.
+
+**Every bug fixed in #63 and #65 was a call-site or render bug, and the unit
+suite was 19/19 green the whole time it was broken.** Pure-logic bug → unit
+test; anything involving construction, rendering, the DOM, or two widgets
+coexisting → e2e.
+
+**Prove the test fails without the fix.** Revert the fix, watch it go red, then
+restore. Two assertions written during the #65 review passed with the fix
+reverted and had to be deleted — d3's normalisation made the thing they claimed
+to check unobservable. A test that never failed proves nothing.
+
+---
+
+## Guardrails
+
+- **Don't push to `main`.** Open a PR; ivelascog reviews. `dev` is a scratch
+  integration branch and gets reset to `main` freely.
+- **Don't force-push a shared branch** without saying so. Prefer merging `main`
+  in over rebasing a branch someone else has commits on.
+- **Don't delete branches on evidence of ancestry alone** — see the squash note
+  above.
+- **Don't bump the version or publish to npm** without being asked.

--- a/README.md
+++ b/README.md
@@ -288,6 +288,52 @@ filters: [
 
 
 
+## Contributing
+
+```bash
+npm ci
+npm run build        # rollup -> dist/{TimeWidget.js,.esm.js,.min.js}
+npm run test:all     # unit tests -> build -> e2e. The full gate.
+```
+
+To try a change in a browser, serve the **repository root** — the examples load
+`../dist/TimeWidget.js`, so serving `example/` on its own gives you a 404:
+
+```bash
+npm run build
+npx http-server . -p 8099 -c-1 -a 127.0.0.1
+# then open http://localhost:8099/example/stocks.html
+```
+
+`example/stocks.html` is the most complete demo (real data, brushes, group
+medians, reference curves). `npm run dev` is a rollup watch build, not a server.
+
+Working with an AI coding agent? [`CLAUDE.md`](./CLAUDE.md) documents the
+architecture, conventions, and the non-obvious traps in this codebase.
+
+### Testing
+
+Two tiers, because they catch different things:
+
+| Command | What it covers |
+|---|---|
+| `npm test` | Jest unit tests over the pure logic in `src/utils.js`, `src/BVH.js` |
+| `npm run test:e2e` | Playwright, real browser, driving the built bundle |
+
+**Put a test at the tier that can actually observe the bug.** Pure-logic bug →
+unit test. Anything involving construction, rendering, the DOM, or two widgets
+on one page → e2e; those bugs are invisible to the unit suite, which has been
+fully green while exactly that class of bug was live.
+
+Run `npm run build` before `npm run test:e2e` — the e2e suite drives `dist/`,
+so an un-built source change simply isn't there.
+
+**Prove a new test fails without its fix.** Revert the fix, watch the test go
+red, then restore it. A test that has never failed proves nothing, and it is
+easy to write an assertion that quietly holds either way.
+
+Both tiers run in CI on every pull request.
+
 ## License
 
 TimeWidget.js is licensed under the MIT license. (http://opensource.org/licenses/MIT)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.20.0",
+        "@playwright/test": "^1.62.1",
         "@rollup/plugin-babel": "^6.0.3",
         "@rollup/plugin-commonjs": "^24.0.1",
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -25,6 +26,7 @@
         "eslint-plugin-jest": "^28.11.0",
         "eslint-plugin-prettier": "^4.2.1",
         "globals": "^15.14.0",
+        "http-server": "^14.1.1",
         "jest": "^29.7.0",
         "license": "^1.0.3",
         "lint-staged": "^13.1.0",
@@ -1393,6 +1395,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.0.3.tgz",
@@ -1999,6 +2017,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -2149,6 +2174,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2225,6 +2270,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -2531,6 +2607,16 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
+    },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -2998,12 +3084,13 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -3100,6 +3187,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -3137,6 +3239,39 @@
       "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -3517,6 +3652,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/execa": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
@@ -3700,6 +3842,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3721,10 +3884,14 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/fuzzy-search": {
       "version": "3.2.1",
@@ -3750,6 +3917,31 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -3757,6 +3949,20 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -3825,6 +4031,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -3852,10 +4071,59 @@
         "node": ">=4"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/htl": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/htl/-/htl-0.3.1.tgz",
       "integrity": "sha512-1LBtd+XhSc+++jpOOt0lCcEycXs/zTQSupOISnVAUmvGBpV7DH+C2M6hwV7zWYfpTMMg9ch4NO0lHiOTAMHdVA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -3865,6 +4133,89 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-server/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/http-server/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/http-server/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/human-signals": {
       "version": "3.0.1",
@@ -5958,6 +6309,16 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5988,6 +6349,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -6012,11 +6386,22 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -6073,10 +6458,14 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6103,6 +6492,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -6302,6 +6701,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+      "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6404,6 +6849,23 @@
         }
       ]
     },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6454,6 +6916,13 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -6719,6 +7188,13 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -6762,6 +7238,82 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -7152,6 +7704,18 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -7204,6 +7768,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
@@ -7237,6 +7808,20 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {
@@ -8388,6 +8973,15 @@
       "integrity": "sha512-IHjc31WXciQT3hfvdY+M59jBkQp70Fpr04tNDVO5rez2PNv4u8tE6w//CkU+GeBoO9k2ahneSqzjzvlgjyjkGw==",
       "dev": true
     },
+    "@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.62.1"
+      }
+    },
     "@rollup/plugin-babel": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.0.3.tgz",
@@ -8821,6 +9415,12 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
+    "async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true
+    },
     "babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -8939,6 +9539,23 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -8990,6 +9607,26 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
       "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "dev": true
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
+    },
+    "call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      }
     },
     "callsites": {
       "version": "3.1.0",
@@ -9214,6 +9851,12 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
+    },
+    "corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
       "dev": true
     },
     "create-jest": {
@@ -9544,12 +10187,12 @@
       "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
     },
     "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       }
     },
     "decamelize": {
@@ -9612,6 +10255,17 @@
         "is-obj": "^2.0.0"
       }
     },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
     "eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -9643,6 +10297,27 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true
+    },
+    "es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0"
       }
     },
     "escalade": {
@@ -9871,6 +10546,12 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
+    },
     "execa": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
@@ -10017,6 +10698,12 @@
       "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -10031,9 +10718,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true
     },
     "fuzzy-search": {
@@ -10054,11 +10741,39 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      }
+    },
     "get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      }
     },
     "get-stream": {
       "version": "6.0.1",
@@ -10101,6 +10816,12 @@
       "integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
       "dev": true
     },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true
+    },
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -10122,16 +10843,105 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true
+    },
+    "hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
     "htl": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/htl/-/htl-0.3.1.tgz",
       "integrity": "sha512-1LBtd+XhSc+++jpOOt0lCcEycXs/zTQSupOISnVAUmvGBpV7DH+C2M6hwV7zWYfpTMMg9ch4NO0lHiOTAMHdVA=="
+    },
+    "html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^2.0.0"
+      }
     },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "requires": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "human-signals": {
       "version": "3.0.1",
@@ -11680,6 +12490,12 @@
         "tmpl": "1.0.5"
       }
     },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -11702,6 +12518,12 @@
         "picomatch": "^2.3.1"
       }
     },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
+    },
     "mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -11717,10 +12539,16 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true
+    },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "natural-compare": {
@@ -11765,9 +12593,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true
     },
     "once": {
@@ -11787,6 +12615,12 @@
       "requires": {
         "mimic-fn": "^4.0.0"
       }
+    },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
     },
     "optionator": {
       "version": "0.9.4",
@@ -11923,6 +12757,32 @@
         "find-up": "^4.0.0"
       }
     },
+    "playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.62.1"
+      }
+    },
+    "playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true
+    },
+    "portfinder": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+      "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+      "dev": true,
+      "requires": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11985,6 +12845,16 @@
       "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
       "dev": true
     },
+    "qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "requires": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      }
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -12016,6 +12886,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
     },
     "resolve": {
@@ -12205,6 +13081,12 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true
+    },
     "semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -12240,6 +13122,54 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      }
+    },
+    "side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      }
+    },
+    "side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      }
+    },
+    "side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      }
     },
     "signal-exit": {
       "version": "3.0.7",
@@ -12522,6 +13452,15 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
+    "union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "requires": {
+        "qs": "^6.4.0"
+      }
+    },
     "unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -12549,6 +13488,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true
     },
     "v8-to-istanbul": {
       "version": "9.2.0",
@@ -12582,6 +13527,15 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
+      }
+    },
+    "whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.6.3"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "build": "rollup -c",
     "dev": "rollup -c -w",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test:e2e": "playwright test",
+    "test:all": "npm test && npm run build && npm run test:e2e",
     "prepublish": "npm run build"
   },
   "keywords": [],
@@ -32,6 +34,7 @@
   "description": "",
   "devDependencies": {
     "@eslint/js": "^9.20.0",
+    "@playwright/test": "^1.62.1",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^24.0.1",
     "@rollup/plugin-node-resolve": "^15.0.1",
@@ -41,6 +44,7 @@
     "eslint-plugin-jest": "^28.11.0",
     "eslint-plugin-prettier": "^4.2.1",
     "globals": "^15.14.0",
+    "http-server": "^14.1.1",
     "jest": "^29.7.0",
     "license": "^1.0.3",
     "lint-staged": "^13.1.0",
@@ -71,5 +75,10 @@
   "engines": {
     "node": ">=20.8.0"
   },
-  "jest": {}
+  "jest": {
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/tests/e2e/"
+    ]
+  }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// The e2e suite drives the built bundle in a real browser. It covers the
+// render-level behaviour the jest suite structurally cannot reach — see
+// tests/e2e/zoom.spec.js for what each case pins.
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  reporter: process.env.CI ? "list" : "line",
+
+  use: {
+    baseURL: "http://127.0.0.1:8099",
+    trace: "on-first-retry",
+  },
+
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+  ],
+
+  // Plain static server over the repo root: the fixture loads both
+  // ../../dist/TimeWidget.js and ../../node_modules/d3/dist/d3.js, so the
+  // root has to be the one directory containing both.
+  // Run `npm run build` first — the suite tests dist/, not src/.
+  webServer: {
+    command: "npx http-server . -p 8099 -c-1 --silent",
+    url: "http://127.0.0.1:8099/tests/e2e/fixture.html",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -23,8 +23,15 @@ export default defineConfig({
   // ../../dist/TimeWidget.js and ../../node_modules/d3/dist/d3.js, so the
   // root has to be the one directory containing both.
   // Run `npm run build` first — the suite tests dist/, not src/.
+  //
+  // -a 127.0.0.1 is not optional. http-server binds 0.0.0.0 by default, and
+  // the served root here is the whole repository — including .git and every
+  // untracked file. Without it, running the suite on a shared network
+  // publishes the repo's history and any local-only files to that network for
+  // as long as the tests take. -d false additionally stops the tree from being
+  // browsable, so the port only answers for paths a test actually requests.
   webServer: {
-    command: "npx http-server . -p 8099 -c-1 --silent",
+    command: "npx http-server . -p 8099 -c-1 -a 127.0.0.1 -d false --silent",
     url: "http://127.0.0.1:8099/tests/e2e/fixture.html",
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,

--- a/tests/e2e/fixture.html
+++ b/tests/e2e/fixture.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>TimeWidget e2e fixture</title>
+    <style>
+      body { margin: 0; font-family: sans-serif; }
+      #target { width: 900px; }
+    </style>
+  </head>
+  <body>
+    <!-- Bare host page for the e2e suite. It deliberately builds no widget of
+         its own: each spec constructs exactly the widget it needs via
+         window.makeWidget(), so tests stay independent of the demo pages in
+         example/, which change for demo reasons rather than test reasons. -->
+    <div id="target"></div>
+
+    <!-- d3 is an external of the rollup build, so the bundle needs a global d3.
+         Served from node_modules rather than a CDN: the version then matches
+         package.json exactly, and CI never fails because a CDN was unreachable. -->
+    <script src="../../node_modules/d3/dist/d3.js"></script>
+    <script src="../../dist/TimeWidget.js"></script>
+
+    <script>
+      // Deterministic sawtooth/sine data — no Math.random, so a failure is
+      // always reproducible.
+      window.makeData = function ({ series = 1, points = 40, dates = false } = {}) {
+        const out = [];
+        for (let s = 0; s < series; s++) {
+          for (let i = 0; i < points; i++) {
+            out.push({
+              t: dates ? new Date(2023, 0, 1 + i) : i,
+              v: 100 + 40 * Math.sin(i / 5 + s / 4),
+              id: "s" + s,
+            });
+          }
+        }
+        return out;
+      };
+
+      // Build a widget and mount it. `hidden` parks it off-screen for tests
+      // that only need a second instance to exist in the document.
+      window.makeWidget = function (data, opts = {}, { hidden = false } = {}) {
+        const w = TimeWidget(data, Object.assign({ x: "t", y: "v", id: "id" }, opts));
+        const host = document.createElement("div");
+        if (hidden) host.style.cssText = "position:absolute;left:-9999px;top:0";
+        document.body.appendChild(host);
+        host.appendChild(w);
+        return w;
+      };
+
+      // Record uncaught errors so a spec can assert that a re-render threw
+      // nothing — several of these bugs aborted the render without rejecting
+      // any promise the test could see.
+      window.__errors = [];
+      window.addEventListener("error", (e) => window.__errors.push(String(e.message)));
+      window.addEventListener("unhandledrejection", (e) =>
+        window.__errors.push(String(e.reason))
+      );
+    </script>
+  </body>
+</html>

--- a/tests/e2e/zoom.spec.js
+++ b/tests/e2e/zoom.spec.js
@@ -1,0 +1,403 @@
+import { test, expect } from "@playwright/test";
+
+// End-to-end coverage for the zoom work in #63 (ts.setDomains / ts.fullExtent)
+// and #65 (median clamp, reference-curve redraw, brush re-projection).
+//
+// These run in a real browser on purpose. Every bug fixed in those two PRs was
+// a call-site or render bug that the unit suite could not see: it stayed at
+// 19/19 green while all of them were live. What each case pins is noted inline
+// so a future failure says which regression came back.
+
+const FIXTURE = "/tests/e2e/fixture.html";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(FIXTURE);
+  await page.waitForFunction(() => !!window.TimeWidget && !!window.makeWidget);
+});
+
+// Fails the test if anything threw into window.onerror. Several of these bugs
+// aborted a re-render without rejecting a promise, so an assertion on the
+// return value alone would pass while the chart was visibly broken.
+async function expectNoPageErrors(page) {
+  expect(await page.evaluate(() => window.__errors)).toEqual([]);
+}
+
+test.describe("#63 domain options and setDomains", () => {
+  // Regression: ts.data() called normalizeDomain(domain, ts.extent), but
+  // ts.extent is never assigned — a numeric domain threw
+  // "Cannot read properties of undefined (reading '0')".
+  test("a numeric xDomain/yDomain option does not throw", async ({ page }) => {
+    const domains = await page.evaluate(() => {
+      const w = window.makeWidget(window.makeData({ points: 40 }), {
+        xDomain: [5, 12],
+        yDomain: [80, 120],
+      });
+      return { x: w.ts.xDomain, y: w.ts.yDomain };
+    });
+    expect(domains.x).toEqual([5, 12]);
+    expect(domains.y).toEqual([80, 120]);
+    await expectNoPageErrors(page);
+  });
+
+  test("a Date xDomain option does not throw", async ({ page }) => {
+    const x = await page.evaluate(() => {
+      const w = window.makeWidget(window.makeData({ points: 40, dates: true }), {
+        x: "t",
+        xDomain: [new Date(2023, 0, 5), new Date(2023, 0, 12)],
+      });
+      return w.ts.xDomain.map((d) => d.toISOString().slice(0, 10));
+    });
+    expect(x).toEqual(["2023-01-05", "2023-01-12"]);
+    await expectNoPageErrors(page);
+  });
+
+  test("an out-of-extent constructor domain is clamped, not applied raw", async ({
+    page,
+  }) => {
+    const { yDomain, extent } = await page.evaluate(() => {
+      const w = window.makeWidget(window.makeData({ points: 40 }), {
+        yDomain: [-5000, 5000],
+      });
+      return { yDomain: w.ts.yDomain, extent: w.ts.getExtent().y };
+    });
+    expect(yDomain).toEqual(extent);
+  });
+
+  // Regression: setDomains passed the whole {x, y} fullExtent object where
+  // normalizeDomain wanted one [lo, hi] pair, so extent[0] was undefined,
+  // every clamp comparison was false, and clamping silently never ran.
+  test("setDomains clamps a request that exceeds the data extent", async ({
+    page,
+  }) => {
+    const { yDomain, extent } = await page.evaluate(() => {
+      const w = window.makeWidget(window.makeData({ points: 40 }));
+      w.ts.setDomains({ y: [-9999, 9999] });
+      return { yDomain: w.ts.yDomain, extent: w.ts.getExtent().y };
+    });
+    expect(yDomain).toEqual(extent);
+  });
+
+  test("setDomains applies an in-range zoom exactly", async ({ page }) => {
+    const yDomain = await page.evaluate(() => {
+      const w = window.makeWidget(window.makeData({ points: 40 }));
+      w.ts.setDomains({ y: [95, 125] });
+      return w.ts.yDomain;
+    });
+    expect(yDomain).toEqual([95, 125]);
+  });
+
+  test("an unrequested axis keeps its current domain", async ({ page }) => {
+    const { before, after } = await page.evaluate(() => {
+      const w = window.makeWidget(window.makeData({ points: 40 }));
+      const before = w.ts.yDomain.slice();
+      w.ts.setDomains({ x: [10, 20] });
+      return { before, after: w.ts.yDomain };
+    });
+    expect(after).toEqual(before);
+  });
+
+  // Regression: fullExtent sat behind `if (!ts.fullExtent)`, so it kept the
+  // first dataset's range forever. Since domains clamp to fullExtent, records
+  // outside that first range could never be brought into view.
+  test("fullExtent follows a new dataset", async ({ page }) => {
+    const { first, second } = await page.evaluate(() => {
+      const w = window.makeWidget(window.makeData({ points: 40 }));
+      const first = w.ts.getExtent().y.slice();
+      const wide = window.makeData({ points: 40 });
+      wide.push({ t: 41, v: 9999, id: "s0" }, { t: 42, v: -9999, id: "s0" });
+      w.ts.data(wide);
+      return { first, second: w.ts.getExtent().y };
+    });
+    expect(second).not.toEqual(first);
+    expect(second[1]).toBeGreaterThanOrEqual(9999);
+  });
+});
+
+test.describe("#65 median binning", () => {
+  // Regression: bins are indexed off the X domain, and the old code only
+  // handled overshooting by exactly one bin. Zooming leaves data far outside
+  // [minX, maxX], so the index landed outside `bins` and threw — aborting the
+  // whole re-render, which is why brushes looked like they re-projected on Y
+  // but not on X.
+  test("zooming X with a brush and medians active does not throw", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const w = window.makeWidget(window.makeData({ series: 30, points: 40 }), {
+        filters: [
+          {
+            name: "G1",
+            isEnable: true,
+            isActive: true,
+            brushes: [
+              {
+                mode: "intersect",
+                aggregation: "and",
+                selectionDomain: [
+                  [10, 130],
+                  [20, 90],
+                ],
+              },
+            ],
+          },
+        ],
+      });
+      w.ts.setDomains({ x: [12, 28] });
+      w.ts.setDomains({ x: [0, 39] });
+      window.__w = w;
+    });
+    await expectNoPageErrors(page);
+  });
+});
+
+test.describe("#65 reference curves", () => {
+  const CURVE = [
+    [30, 120],
+    [0, 100],
+    [20, 140],
+    [10, 90],
+    [39, 150],
+  ];
+
+  // Regression: addReferenceCurves sorted the caller's array in place, under a
+  // comment promising not to mutate.
+  test("the caller's curve array is not mutated", async ({ page }) => {
+    const { length, firstX } = await page.evaluate((curve) => {
+      const w = window.makeWidget(window.makeData({ points: 40 }));
+      const data = curve.slice();
+      w.ts.addReferenceCurves([{ data, color: "red", opacity: 1 }]);
+      return { length: data.length, firstX: data[0][0] };
+    }, CURVE);
+    expect(length).toBe(5);
+    expect(firstX).toBe(30); // still the caller's original order
+  });
+
+  test("the stored copy is sorted by x", async ({ page }) => {
+    const xs = await page.evaluate((curve) => {
+      const w = window.makeWidget(window.makeData({ points: 40 }));
+      w.ts.addReferenceCurves([{ data: curve.slice(), color: "red", opacity: 1 }]);
+      return w.ts._referenceCurves[0].data.map((p) => p[0]);
+    }, CURVE);
+    expect(xs).toEqual([...xs].sort((a, b) => a - b));
+  });
+
+  // Regression: curves given as the constructor option were stored unsorted
+  // while addReferenceCurves() sorted them, so those drew as zig-zags.
+  test("curves given as a constructor option are sorted too", async ({ page }) => {
+    const xs = await page.evaluate((curve) => {
+      const w = window.makeWidget(window.makeData({ points: 40 }), {
+        referenceCurves: [{ data: curve.slice(), color: "red", opacity: 1 }],
+      });
+      return w.ts._referenceCurves[0].data.map((p) => p[0]);
+    }, CURVE);
+    expect(xs).toEqual([...xs].sort((a, b) => a - b));
+  });
+
+  // Regression: addReferenceCurves destructively reassigned c.data to the
+  // subset inside the initial domain, so ts.update() never redrew it and
+  // zooming out could not restore the discarded points.
+  test("curves re-project on zoom and fully restore on zoom out", async ({
+    page,
+  }) => {
+    const r = await page.evaluate((curve) => {
+      const w = window.makeWidget(window.makeData({ points: 40 }));
+      w.ts.addReferenceCurves([{ data: curve.slice(), color: "red", opacity: 1 }]);
+      const d = () => w.querySelector("path.referenceCurve").getAttribute("d");
+      const stored = () => w.ts._referenceCurves[0].data.length;
+
+      const full = d();
+      const storedFull = stored();
+      w.ts.setDomains({ x: [15, 25] });
+      const zoomed = d();
+      const storedZoomed = stored();
+      w.ts.setDomains({ x: [0, 39] });
+      return { full, zoomed, back: d(), storedFull, storedZoomed, storedBack: stored() };
+    }, CURVE);
+
+    expect(r.zoomed).not.toBe(r.full); // the curve tracked the zoom
+    expect(r.back).toBe(r.full); // and came back identical
+    expect(r.storedZoomed).toBe(r.storedFull); // nothing was destroyed
+    expect(r.storedBack).toBe(r.storedFull);
+    await expectNoPageErrors(page);
+  });
+});
+
+test.describe("#65 clip-path", () => {
+  test("gReferences is clipped", async ({ page }) => {
+    const { clipId, ref } = await page.evaluate(() => {
+      const w = window.makeWidget(window.makeData({ points: 40 }));
+      return {
+        clipId: w.querySelector("clipPath").id,
+        ref: w.querySelector("g.gReferences").getAttribute("clip-path"),
+      };
+    });
+    expect(clipId).toMatch(/^plotClip-\d+$/);
+    expect(ref).toBe(`url(#${clipId})`);
+  });
+
+  // Regression: the id was hardcoded. Unlike the other ids here, which are only
+  // used as selectors scoped to a widget's own subtree, clip-path="url(#…)" is
+  // resolved document-wide — so a second widget was clipped by the first one's
+  // rect.
+  test("each widget instance gets its own clip id", async ({ page }) => {
+    const ids = await page.evaluate(() => {
+      window.makeWidget(window.makeData({ points: 20 }), {}, { hidden: true });
+      window.makeWidget(window.makeData({ points: 20 }), {}, { hidden: true });
+      window.makeWidget(window.makeData({ points: 20 }), {}, { hidden: true });
+      return [...document.querySelectorAll("clipPath")].map((c) => c.id);
+    });
+    expect(ids.length).toBe(3);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("the clip id survives a re-render", async ({ page }) => {
+    const { before, after, ref } = await page.evaluate(() => {
+      const w = window.makeWidget(window.makeData({ points: 40 }));
+      const before = w.querySelector("clipPath").id;
+      w.ts.setDomains({ x: [10, 30] });
+      return {
+        before,
+        after: w.querySelector("clipPath").id,
+        ref: w.querySelector("g.gReferences").getAttribute("clip-path"),
+      };
+    });
+    expect(after).toBe(before);
+    expect(ref).toBe(`url(#${before})`); // still resolvable after update
+  });
+});
+
+test.describe("#65 brush re-projection", () => {
+  // Builds a widget carrying one brush, via the same addFilters path the app
+  // uses when restoring state.
+  const withBrush = (selectionDomain, opts = {}) => ({ selectionDomain, opts });
+
+  async function build(page, selectionDomain, opts = {}) {
+    return page.evaluate(
+      ({ selectionDomain, opts }) => {
+        const w = window.makeWidget(
+          window.makeData({ series: 30, points: 40 }),
+          Object.assign(
+            {
+              filters: [
+                {
+                  name: "G1",
+                  isEnable: true,
+                  isActive: true,
+                  brushes: [
+                    { mode: "intersect", aggregation: "and", selectionDomain },
+                  ],
+                },
+              ],
+            },
+            opts
+          )
+        );
+        window.__w = w;
+        // rect.selection also matches d3's hidden pending brush, which carries
+        // no width/height — take the rendered one.
+        const rect = [...w.querySelectorAll("rect.selection")].find(
+          (r) => r.getAttribute("width") !== null
+        );
+        return {
+          width: rect && +rect.getAttribute("width"),
+          height: rect && +rect.getAttribute("height"),
+        };
+      },
+      { selectionDomain, opts }
+    );
+  }
+
+  test("a brush inside the domain renders with positive extent", async ({
+    page,
+  }) => {
+    const r = await build(page, [
+      [10, 130],
+      [20, 90],
+    ]);
+    expect(r.width).toBeGreaterThan(0);
+    expect(r.height).toBeGreaterThan(0);
+    await expectNoPageErrors(page);
+  });
+
+  // NOTE on clampToDomain's y ordering.
+  //
+  // A selectionDomain is [[xLow, yHigh], [xHigh, yLow]] — built from pixel
+  // corners, and scaleY inverts, so the first pair holds the HIGH value.
+  // clampToDomain originally rebuilt it ascending, contradicting that
+  // convention (and isInsideDomain, which encodes it correctly).
+  //
+  // There is deliberately NO e2e case for that ordering, because it is not
+  // observable here: the two orderings name the same pair of corners,
+  // d3.brush.move normalises the extent, and newBrush() stores
+  // selectionDomain: null and re-derives it from the normalised pixels. The
+  // wrong order is laundered before anything can see it. The contract is
+  // pinned at the unit level instead — tests/clampToDomain.test.js, which does
+  // fail when the ordering is reversed. Asserting it here would be a test that
+  // passes either way.
+  // There is also no e2e case asserting that an out-of-domain selectionDomain
+  // ends up inside the domain. It was written and then deleted: it passed with
+  // clampToDomain stubbed out to return its input unchanged. d3's brush
+  // `extent` already confines the rendered pixels to the plot area, and the
+  // stored domain is re-derived from those pixels, so that assertion holds
+  // whether or not any clamping ran. It read as coverage and was worth nothing.
+  test("a brush outside the domain still renders after clamping", async ({
+    page,
+  }) => {
+    const r = await build(
+      page,
+      [
+        [10, 500],
+        [20, -500],
+      ],
+      { yDomain: [80, 120] }
+    );
+    expect(r.width).toBeGreaterThan(0);
+    expect(r.height).toBeGreaterThan(0);
+    await expectNoPageErrors(page);
+  });
+
+  test("a brush keeps its data coordinates across an x zoom", async ({ page }) => {
+    await build(page, [
+      [10, 130],
+      [20, 90],
+    ]);
+    const r = await page.evaluate(() => {
+      const w = window.__w;
+      const rect = () =>
+        [...w.querySelectorAll("rect.selection")].find(
+          (r) => r.getAttribute("width") !== null
+        );
+      const before = +rect().getAttribute("width");
+      w.ts.setDomains({ x: [5, 25] }); // zoom in; brush still fully contained
+      return { before, after: +rect().getAttribute("width") };
+    });
+    // Same data range over a narrower domain must render wider, not vanish or
+    // stay pinned to its old pixels.
+    expect(r.after).toBeGreaterThan(r.before);
+    await expectNoPageErrors(page);
+  });
+
+  test("a user-drawn brush survives a zoom", async ({ page }) => {
+    await page.evaluate(() => {
+      window.__w = window.makeWidget(window.makeData({ series: 30, points: 40 }));
+    });
+    const box = await page.locator("#target svg, svg").first().boundingBox();
+    await page.mouse.move(box.x + box.width * 0.3, box.y + box.height * 0.35);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width * 0.6, box.y + box.height * 0.65, {
+      steps: 12,
+    });
+    await page.mouse.up();
+
+    const drawn = await page.evaluate(
+      () =>
+        [...window.__w.querySelectorAll("rect.selection")].filter(
+          (r) => r.getAttribute("width") !== null && +r.getAttribute("width") > 0
+        ).length
+    );
+    expect(drawn).toBeGreaterThan(0);
+
+    await page.evaluate(() => window.__w.ts.setDomains({ x: [5, 30] }));
+    await expectNoPageErrors(page);
+  });
+});


### PR DESCRIPTION
Claude (Opus 5, 1M context) in behalf of John

## Why

Every bug we fixed in #63 and #65 was a **call-site or render** bug — a crash on construction, a clamp that silently no-opped, a median index out of range during a zoom, curve data destroyed on redraw, a DOM id that collided between two widgets.

The unit suite was **19/19 green the entire time all of them were live.** It only ever called the pure helpers directly, with hand-written correct arguments. Nothing exercised a real widget. This adds the tier that would have caught them.

## What

| | |
|---|---|
| `tests/e2e/fixture.html` | bare host exposing `window.makeWidget` / `makeData` |
| `tests/e2e/zoom.spec.js` | 19 cases across the #63 domain API and #65 median/curve/clip-path/brush behaviour |
| `playwright.config.js` | static server over the repo root, chromium |
| `.github/workflows/node.js.yml` | new `e2e` job: build → install chromium → run → upload report on failure |
| `CLAUDE.md` / `AGENTS.md` | agent guide: build/test/run, module map, conventions, traps |

```bash
npm run test:all     # 38 unit + build + 19 e2e
```

Two details worth knowing:

- Specs build their own widgets rather than driving the `example/` pages — those change for demo reasons, not test reasons.
- d3 is served from `node_modules`, not a CDN, so the version matches `package.json` and CI can't fail because a CDN was unreachable.
- jest's default `testMatch` would have picked up `zoom.spec.js`, hence `testPathIgnorePatterns`.
- The e2e suite drives `dist/`, so CI builds before running it.

## Every case was mutation-tested

I reverted each fix and confirmed the corresponding test goes red:

| Fix reverted | Test |
|---|---|
| `setDomains` passes the `{x,y}` object again | ✅ fails |
| Constructor domain validated against `ts.extent` | ✅ fails |
| `fullExtent` captured once | ✅ fails |
| Median bin clamp removed | ✅ fails |
| Hardcoded `plotClip` id | ✅ fails |
| Curves stored by reference and sorted in place | ✅ fails |
| Constructor curves unsorted | ✅ fails |
| Destructive curve filter on redraw | ✅ fails |

## Two tests I wrote and then deleted

Both **passed with the fix reverted**, so they were green-looking coverage worth nothing. Rather than ship them I removed them and left a comment at each spot explaining why there is deliberately no test there.

1. **`clampToDomain`'s y ordering.** `d3.brush.move` normalises the extent, and `newBrush()` stores `selectionDomain: null` and re-derives it from the rendered pixels — the ordering is laundered before the DOM can show it. That contract is pinned at the unit tier instead, where `tests/clampToDomain.test.js` does fail when it's reversed.

2. **"A clamped brush ends up inside the domain."** d3's `brush.extent` already confines rendered pixels to the plot area, so this held even with `clampToDomain` stubbed out to return its input unchanged.

### ⚠️ A correction to what I wrote on #65

@ivelascog — finding (1) means **I overstated that bug** in the #65 review and in its merge commit. I said the y ordering "mirrored the brush vertically: a 180px box came back as -180." The arithmetic on the returned array was right, but I asserted it reached the screen, and it does not:

```
correct [[10,120],[20,100]] -> pixels [[231,0],[462,260]]
flipped [[10,100],[20,120]] -> pixels [[231,260],[462,0]]
```

Same two corners, opposite order — d3 normalises it away. I verified by reverting the fix and re-reading the stored value: still correct.

What was true: the function contradicted the convention `isInsideDomain` encodes, which is a real inconsistency and a trap for the next caller. What was false: that it produced a visibly mirrored brush. It should have been a code-quality finding, not a blocking one. The fix is still right; the severity I put on it was not. Sorry for the noise.

## Agent guide

`CLAUDE.md` documents the traps as *mechanisms*, not rules:

- **`rollup-plugin-ascii` bundles a pre-ES2018 acorn** that runs before Babel, so `??` and object spread fail at bundle time while `npm test` stays green. This bit me twice.
- **`selectionDomain` is `[[xLow, yHigh], [xHigh, yLow]]`** — pixel corners through an inverted `scaleY`.
- **`rect.selection` also matches d3's hidden pending brush**, which has no width/height. Measuring the wrong one cost me an afternoon.
- **`clip-path="url(#id)"` resolves document-wide**, unlike `#render`/`#brushes` which are only ever scoped selectors.
- **Squash-merging breaks ancestry**, so `git branch --merged` misreports merged branches.

Happy to drop or reword any of it — you know this codebase better than the guide does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
